### PR TITLE
fix(Euclogic): Change LFO output to 0-10V unipolar ramp

### DIFF
--- a/src/modules/Euclogic2/Euclogic2.cpp
+++ b/src/modules/Euclogic2/Euclogic2.cpp
@@ -55,19 +55,6 @@ static const std::vector<std::string> QUANT_LABELS_2 = {
 // Forward declaration
 struct Euclogic2;
 
-// Generate LFO waveform from phase [0, 1) - returns [-1, 1]
-// Fixed waveform per channel: Ch1=Sine, Ch2=Triangle
-static float generateLFOWave2(int channel, float phase) {
-    switch (channel) {
-        case 0:  // Ch1: Sine
-            return std::sin(phase * 2.f * M_PI);
-        case 1:  // Ch2: Triangle
-            return (phase < 0.5f) ? (phase * 4.f - 1.f) : (3.f - phase * 4.f);
-        default:
-            return 0.f;
-    }
-}
-
 // Simple 2-input truth table (4 states)
 struct TruthTable2 {
     std::array<uint8_t, 4> mapping = {0, 1, 2, 3};  // Default: pass-through
@@ -440,12 +427,11 @@ struct Euclogic2 : Module {
             outputs[TRIG_OUTPUT + i].setVoltage(trigPulse[i].process(dt) ? 10.f : 0.f);
             lights[GATE_LIGHT + i].setBrightness(gate ? 1.f : 0.f);
 
-            // LFO output
+            // LFO output: unipolar ramp 0-10V tracking step position
             int steps = engines[i].steps;
             int currentStep = engines[i].currentStep;
             float phase = (steps > 0) ? (float)currentStep / (float)steps : 0.f;
-            float lfoValue = generateLFOWave2(i, phase);
-            outputs[LFO_OUTPUT + i].setVoltage(lfoValue * 5.f);
+            outputs[LFO_OUTPUT + i].setVoltage(phase * 10.f);
         }
 
         // Update LED matrix lights (4 states × 2 outputs)


### PR DESCRIPTION
## Summary
- Replaces per-channel bipolar waveform shapes (sine, saw up, saw down, triangle) with a simple 0-10V unipolar ramp tracking step position 0..N
- Removes unused `generateLFOWave()` and `generateLFOWave2()` functions
- Applied to both Euclogic (4ch) and Euclogic2 (2ch)

Closes #6

## Test plan
- [x] Build passes (`just build`)
- [ ] Verify LFO outputs ramp 0-10V in VCV Rack when clocked
- [ ] Verify ramp resets to 0V on pattern reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)