### PR TITLE
Fix undo and add redo for Euclogic truth tables

### DIFF
--- a/src/modules/Euclogic/Euclogic.cpp
+++ b/src/modules/Euclogic/Euclogic.cpp
@@ -92,6 +92,7 @@ struct Euclogic : Module {
         RANDOM_PARAM,
         MUTATE_PARAM,
         UNDO_PARAM,
+        REDO_PARAM,
         ENUMS(STEPS_PARAM, NUM_CHANNELS),
         ENUMS(HITS_PARAM, NUM_CHANNELS),
         ENUMS(QUANT_PARAM, NUM_CHANNELS),
@@ -139,6 +140,7 @@ struct Euclogic : Module {
     dsp::SchmittTrigger randomTrigger;
     dsp::SchmittTrigger mutateTrigger;
     dsp::SchmittTrigger undoTrigger;
+    dsp::SchmittTrigger redoTrigger;
 
     float clockPeriod = DEFAULT_CLOCK_PERIOD;
     float timeSinceClock = 0.f;
@@ -179,6 +181,7 @@ struct Euclogic : Module {
         configButton(RANDOM_PARAM, "Random");
         configButton(MUTATE_PARAM, "Mutate");
         configButton(UNDO_PARAM, "Undo");
+        configButton(REDO_PARAM, "Redo");
 
         // Per-channel parameters
         for (int i = 0; i < NUM_CHANNELS; i++) {
@@ -269,6 +272,9 @@ struct Euclogic : Module {
         }
         if (undoTrigger.process(params[UNDO_PARAM].getValue())) {
             truthTable.undo();
+        }
+        if (redoTrigger.process(params[REDO_PARAM].getValue())) {
+            truthTable.redo();
         }
 
         // Clock handling - measure period
@@ -832,10 +838,11 @@ struct EuclogicWidget : ModuleWidget {
 
         addParam(createParamCentered<RoundSmallBlackKnob>(mm2px(Vec(colBase + 68.f, yMaster)), module, Euclogic::SWING_PARAM));
 
-        // Row 2: Random, Mutate, Undo buttons
-        addParam(createParamCentered<VCVButton>(mm2px(Vec(colBase + 20.f, yMaster2)), module, Euclogic::RANDOM_PARAM));
-        addParam(createParamCentered<VCVButton>(mm2px(Vec(colBase + 44.f, yMaster2)), module, Euclogic::MUTATE_PARAM));
-        addParam(createParamCentered<VCVButton>(mm2px(Vec(colBase + 68.f, yMaster2)), module, Euclogic::UNDO_PARAM));
+        // Row 2: Random, Mutate, Undo, Redo buttons
+        addParam(createParamCentered<VCVButton>(mm2px(Vec(colBase + 8.f, yMaster2)), module, Euclogic::RANDOM_PARAM));
+        addParam(createParamCentered<VCVButton>(mm2px(Vec(colBase + 28.f, yMaster2)), module, Euclogic::MUTATE_PARAM));
+        addParam(createParamCentered<VCVButton>(mm2px(Vec(colBase + 48.f, yMaster2)), module, Euclogic::UNDO_PARAM));
+        addParam(createParamCentered<VCVButton>(mm2px(Vec(colBase + 68.f, yMaster2)), module, Euclogic::REDO_PARAM));
 
         // Row 3: Outputs (Gates + Triggers + LFOs)
         for (int i = 0; i < Euclogic::NUM_CHANNELS; i++) {

--- a/test/test_truth_table.cpp
+++ b/test/test_truth_table.cpp
@@ -1,0 +1,226 @@
+/******************************************************************************
+ * Unit tests for TruthTable undo/redo functionality
+ * Tests both TruthTable (4-channel) from TruthTable.hpp
+ *
+ * Build: g++ -std=c++17 -I../src/modules/Euclogic -o test_truth_table test_truth_table.cpp
+ * Run:   ./test_truth_table
+ ******************************************************************************/
+
+#include <cassert>
+#include <iostream>
+#include "../src/modules/Euclogic/TruthTable.hpp"
+
+void test_undo_after_mutate() {
+    WiggleRoom::TruthTable tt;
+    tt.setSeed(42);
+    auto original = tt.serialize();
+
+    tt.mutate();  // pushUndo + modify
+    auto mutated = tt.serialize();
+    assert(original != mutated);
+
+    bool result = tt.undo();
+    assert(result);
+    assert(tt.serialize() == original);
+    std::cout << "PASS: test_undo_after_mutate\n";
+}
+
+void test_undo_multiple() {
+    WiggleRoom::TruthTable tt;
+    tt.setSeed(42);
+    auto state0 = tt.serialize();
+
+    tt.mutate();
+    auto state1 = tt.serialize();
+
+    tt.mutate();
+    // auto state2 = tt.serialize();
+
+    bool r1 = tt.undo();
+    assert(r1);
+    assert(tt.serialize() == state1);
+
+    bool r2 = tt.undo();
+    assert(r2);
+    assert(tt.serialize() == state0);
+    std::cout << "PASS: test_undo_multiple\n";
+}
+
+void test_undo_empty_noop() {
+    WiggleRoom::TruthTable tt;
+    auto original = tt.serialize();
+    bool result = tt.undo();
+    assert(!result);
+    assert(tt.serialize() == original);
+    std::cout << "PASS: test_undo_empty_noop\n";
+}
+
+void test_redo_basic() {
+    WiggleRoom::TruthTable tt;
+    tt.setSeed(42);
+    auto original = tt.serialize();
+
+    tt.mutate();
+    auto mutated = tt.serialize();
+
+    tt.undo();
+    assert(tt.serialize() == original);
+
+    bool result = tt.redo();
+    assert(result);
+    assert(tt.serialize() == mutated);
+    std::cout << "PASS: test_redo_basic\n";
+}
+
+void test_redo_multiple() {
+    WiggleRoom::TruthTable tt;
+    tt.setSeed(42);
+    auto state0 = tt.serialize();
+
+    tt.mutate();
+    auto state1 = tt.serialize();
+
+    tt.mutate();
+    auto state2 = tt.serialize();
+
+    // Undo twice
+    tt.undo();
+    tt.undo();
+    assert(tt.serialize() == state0);
+
+    // Redo twice
+    tt.redo();
+    assert(tt.serialize() == state1);
+
+    tt.redo();
+    assert(tt.serialize() == state2);
+    std::cout << "PASS: test_redo_multiple\n";
+}
+
+void test_redo_cleared_on_new_action() {
+    WiggleRoom::TruthTable tt;
+    tt.setSeed(42);
+
+    tt.mutate();
+    tt.undo();
+
+    tt.randomize();  // This should clear redo stack
+    bool result = tt.redo();
+    assert(!result);
+    std::cout << "PASS: test_redo_cleared_on_new_action\n";
+}
+
+void test_redo_empty_noop() {
+    WiggleRoom::TruthTable tt;
+    auto original = tt.serialize();
+    bool result = tt.redo();
+    assert(!result);
+    assert(tt.serialize() == original);
+    std::cout << "PASS: test_redo_empty_noop\n";
+}
+
+void test_undo_after_randomize() {
+    WiggleRoom::TruthTable tt;
+    tt.setSeed(42);
+    auto original = tt.serialize();
+
+    tt.randomize();
+    assert(tt.serialize() != original);
+
+    tt.undo();
+    assert(tt.serialize() == original);
+    std::cout << "PASS: test_undo_after_randomize\n";
+}
+
+void test_undo_after_toggle() {
+    WiggleRoom::TruthTable tt;
+    auto original = tt.serialize();
+
+    tt.pushUndo();  // Manual push before toggle (as done in UI code)
+    tt.toggleBit(0, 0);
+    assert(tt.serialize() != original);
+
+    tt.undo();
+    assert(tt.serialize() == original);
+    std::cout << "PASS: test_undo_after_toggle\n";
+}
+
+void test_undo_redo_interleaved() {
+    WiggleRoom::TruthTable tt;
+    tt.setSeed(42);
+    auto state0 = tt.serialize();
+
+    tt.mutate();
+    auto state1 = tt.serialize();
+
+    tt.mutate();
+    auto state2 = tt.serialize();
+
+    // Undo to state1
+    tt.undo();
+    assert(tt.serialize() == state1);
+
+    // New action from state1 - should clear redo
+    tt.mutate();
+    auto state3 = tt.serialize();
+
+    // Can't redo to state2 anymore
+    bool result = tt.redo();
+    assert(!result);
+    assert(tt.serialize() == state3);
+
+    // But can still undo back through state1 to state0
+    tt.undo();  // state3 -> state1
+    assert(tt.serialize() == state1);
+
+    tt.undo();  // state1 -> state0
+    assert(tt.serialize() == state0);
+
+    std::cout << "PASS: test_undo_redo_interleaved\n";
+}
+
+void test_undo_after_load_preset() {
+    WiggleRoom::TruthTable tt;
+    auto original = tt.serialize();
+
+    tt.loadPreset("XOR");
+    auto xorState = tt.serialize();
+    assert(original != xorState);
+
+    tt.undo();
+    assert(tt.serialize() == original);
+    std::cout << "PASS: test_undo_after_load_preset\n";
+}
+
+void test_toggle_clears_redo() {
+    WiggleRoom::TruthTable tt;
+    tt.setSeed(42);
+
+    tt.mutate();
+    tt.undo();
+
+    // Manual toggle (as in UI) should clear redo
+    tt.pushUndo();
+    tt.toggleBit(0, 0);
+
+    bool result = tt.redo();
+    assert(!result);
+    std::cout << "PASS: test_toggle_clears_redo\n";
+}
+
+int main() {
+    test_undo_after_mutate();
+    test_undo_multiple();
+    test_undo_empty_noop();
+    test_redo_basic();
+    test_redo_multiple();
+    test_redo_cleared_on_new_action();
+    test_redo_empty_noop();
+    test_undo_after_randomize();
+    test_undo_after_toggle();
+    test_undo_redo_interleaved();
+    test_undo_after_load_preset();
+    test_toggle_clears_redo();
+    std::cout << "\nAll TruthTable tests passed!\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- **Fixes broken undo** in both Euclogic (4-channel) and Euclogic2 (2-channel) truth tables
- **Adds redo functionality** with a new Redo button on both module panels
- **Includes unit tests** for undo/redo behavior (12 test cases)

### What was broken
- **TruthTable (4-channel):** `undo()` called `popUndo()` which restored the previous mapping but did not save the current state -- making the undone state unrecoverable
- **TruthTable2 (2-channel):** Used a single `undoMapping` with `std::swap`, creating a toggle between two states rather than proper multi-step undo

### What changed
- Both truth tables now use vector-based `undoHistory` and `redoHistory` stacks
- `pushUndo()` saves current state and clears the redo stack (new actions invalidate redo)
- `undo()` saves current state to redo stack before restoring from undo stack
- `redo()` saves current state to undo stack before restoring from redo stack
- Added `REDO_PARAM` enum, `redoTrigger`, and `VCVButton` widget to both modules

## Test plan
- [x] Unit tests pass: 12 test cases covering undo after mutate/randomize/toggle, multi-step undo, redo, redo cleared on new action, interleaved undo/redo, and edge cases
- [x] Existing euclogic_test passes (truth table undo, randomize, mutate, Euclidean patterns)
- [x] Full plugin build succeeds
- [ ] Manual test in VCV Rack: click truth table cells, use Random/Mutate, verify Undo restores and Redo re-applies

Closes #7
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)