### PR TITLE
feat: Add CV inputs for isotope, shape, and decay to ACID9Voice

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -130,7 +130,7 @@
     {
       "slug": "ACID9Voice",
       "name": "ACID9 Voice",
-      "description": "Acid synthesizer voice with tri-core morphing oscillator, dual filters, stereo delay with ghost mode, and accent/slide control",
+      "description": "Acid synthesizer voice with tri-core morphing oscillator, dual filters, stereo delay with ghost mode, accent/slide control, and CV inputs for shape, isotope, and decay",
       "tags": ["Synth voice", "Oscillator", "Filter"]
     },
     {


### PR DESCRIPTION
## Summary
- Adds three new CV inputs to ACID9Voice: Shape CV, Isotope CV, Decay CV
- CV modulation is applied additively in the C++ wrapper before Faust processing
- Shape/Isotope: ±5V maps to ±0.5 (half range modulation)
- Decay: ±5V maps to ±1.0s modulation

Closes #3

## Test plan
- [ ] Build succeeds with `just build`
- [ ] Shape CV modulates waveform morphing (saw→sharktooth→square)
- [ ] Isotope CV modulates detune/stereo spread
- [ ] Decay CV modulates filter envelope decay time
- [ ] Parameters clamp correctly at min/max values
- [ ] Module still works correctly without CV inputs connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)