### PR TITLE
feat: Add pre-logic gate outputs to Euclogic modules

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -154,13 +154,13 @@
     {
       "slug": "Euclogic",
       "name": "Euclogic",
-      "description": "Euclidean rhythm generator with logic operations",
+      "description": "4-channel Euclidean rhythm generator with truth table logic and pre-logic gate outputs",
       "tags": ["Clock modulator", "Sequencer"]
     },
     {
       "slug": "Euclogic2",
       "name": "Euclogic 2",
-      "description": "Advanced Euclidean rhythm generator with expanded logic operations",
+      "description": "Compact 2-channel Euclidean rhythm generator with truth table logic and pre-logic gate outputs",
       "tags": ["Clock modulator", "Sequencer"]
     },
     {


### PR DESCRIPTION
## Summary
- Adds per-channel pre-logic gate outputs to both Euclogic (4ch) and Euclogic2 (2ch)
- These outputs tap the signal after the Euclidean engine + Prob A but before the truth table
- Allows users to access raw rhythmic patterns alongside logic-processed outputs

Closes #4

## Test plan
- [ ] Build succeeds with `just build`
- [ ] Pre-logic gates output 10V when Euclidean hit passes Prob A
- [ ] Pre-logic gates are independent of truth table state
- [ ] Post-logic gates still work correctly
- [ ] Both Euclogic and Euclogic2 modules work

🤖 Generated with [Claude Code](https://claude.com/claude-code)