### PR TITLE
Refactor Euclogic modules to shared core + add PRE_GATE to Euclogic3

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -166,7 +166,7 @@
     {
       "slug": "Euclogic3",
       "name": "Euclogic 3",
-      "description": "3-channel Euclidean rhythm generator with 8-state truth table logic",
+      "description": "3-channel Euclidean rhythm generator with 8-state truth table logic and pre-logic gate outputs",
       "tags": ["Clock modulator", "Sequencer"]
     },
     {

--- a/src/modules/Euclogic/EuclogicCore.hpp
+++ b/src/modules/Euclogic/EuclogicCore.hpp
@@ -1,0 +1,518 @@
+#pragma once
+/******************************************************************************
+ * EUCLOGIC CORE
+ * Shared template for 2/3/4-channel Euclidean sequencer + truth table modules.
+ *
+ * Template parameters:
+ *   N            - Number of channels (2, 3, or 4)
+ *   HAS_PRE_GATE - Whether the module has pre-logic gate outputs
+ *
+ * The module struct must provide standard VCV Rack enums (ParamId, InputId,
+ * OutputId, LightId) matching the expected layout.
+ ******************************************************************************/
+
+#include "rack.hpp"
+#include "DSP.hpp"
+#include "EuclideanEngine.hpp"
+#include "TruthTable.hpp"
+#include "ProbabilityGate.hpp"
+#include <atomic>
+#include <vector>
+#include <string>
+
+using namespace rack;
+
+namespace WiggleRoom {
+
+// ============================================================================
+// Shared constants and tables
+// ============================================================================
+
+namespace EuclogicConstants {
+    static constexpr float TRIGGER_PULSE_DURATION = 1e-3f;   // 1ms
+    static constexpr float RETRIG_GAP_DURATION = 0.5e-3f;    // 0.5ms gap for retrigger
+    static constexpr float SCHMITT_LOW = 0.1f;
+    static constexpr float SCHMITT_HIGH = 1.0f;
+    static constexpr float DEFAULT_CLOCK_PERIOD = 0.5f;      // 120 BPM
+
+    // Speed ratio values (/16 to x16)
+    inline const std::vector<float>& speedRatios() {
+        static const std::vector<float> v = {
+            1.f/16, 1.f/12, 1.f/8, 1.f/6, 1.f/4, 1.f/3, 1.f/2, 2.f/3,
+            1.f,  // x1 (index 8)
+            3.f/2, 2.f, 3.f, 4.f, 6.f, 8.f, 12.f, 16.f
+        };
+        return v;
+    }
+
+    inline const std::vector<std::string>& speedLabels() {
+        static const std::vector<std::string> v = {
+            "/16", "/12", "/8", "/6", "/4", "/3", "/2", "/1.5",
+            "x1",
+            "x1.5", "x2", "x3", "x4", "x6", "x8", "x12", "x16"
+        };
+        return v;
+    }
+
+    // Quant ratio values (per-channel clock division)
+    inline const std::vector<float>& quantRatios() {
+        static const std::vector<float> v = {
+            1.f, 1.f/2, 1.f/4, 1.f/8, 1.f/16
+        };
+        return v;
+    }
+
+    inline const std::vector<std::string>& quantLabels() {
+        static const std::vector<std::string> v = {
+            "x1", "/2", "/4", "/8", "/16"
+        };
+        return v;
+    }
+}
+
+// ============================================================================
+// Snap knob (shared widget)
+// ============================================================================
+
+struct EuclogicSnapKnob : RoundBlackKnob {
+    EuclogicSnapKnob() {
+        snap = true;
+    }
+};
+
+// ============================================================================
+// HitsParamQuantity - limits hits to current steps value
+// ============================================================================
+
+template<typename ModuleT>
+struct EuclogicHitsParamQuantity : ParamQuantity {
+    int channel = 0;
+
+    float getMaxValue() override {
+        ModuleT* m = dynamic_cast<ModuleT*>(module);
+        if (m) {
+            int steps = static_cast<int>(m->params[ModuleT::STEPS_PARAM + channel].getValue());
+            return static_cast<float>(steps);
+        }
+        return 64.f;
+    }
+
+    void setValue(float value) override {
+        value = math::clamp(value, getMinValue(), getMaxValue());
+        ParamQuantity::setValue(value);
+    }
+};
+
+// ============================================================================
+// EuclogicCore<N, HAS_PRE_GATE> - all shared processing logic
+// ============================================================================
+
+template<int N, bool HAS_PRE_GATE>
+struct EuclogicCore {
+    static constexpr int NUM_CHANNELS = N;
+
+    // Core components
+    EuclideanEngine engines[N];
+    ProbabilityGate probA[N];
+    ProbabilityGate probB[N];
+    TruthTableT<N> truthTable;
+
+    // Clock state
+    dsp::SchmittTrigger clockTrigger;
+    dsp::SchmittTrigger resetTrigger;
+    dsp::SchmittTrigger runTrigger;
+    dsp::SchmittTrigger randomTrigger;
+    dsp::SchmittTrigger mutateTrigger;
+    dsp::SchmittTrigger undoTrigger;
+    dsp::SchmittTrigger redoTrigger;
+
+    float clockPeriod = EuclogicConstants::DEFAULT_CLOCK_PERIOD;
+    float timeSinceClock = 0.f;
+    float internalTickPhase = 0.f;
+    bool clockLocked = false;
+    bool running = true;
+    bool hadFirstTick = false;
+    int prevSpeedIdx = 8;  // x1
+    bool swingLong = true;
+
+    // Per-channel state
+    int quantCounter[N] = {};
+    dsp::PulseGenerator trigPulse[N];
+    bool prevGateHigh[N] = {};
+    float retrigGapTimer[N] = {};
+
+    // Display state (atomic for thread safety between audio + UI)
+    std::atomic<uint8_t> currentInputState{0};
+    std::atomic<bool> gateStates[N];
+    std::atomic<bool> preGateStates[N];
+
+    EuclogicCore() {
+        for (int i = 0; i < N; i++) {
+            gateStates[i].store(false);
+            preGateStates[i].store(false);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // configureParams — called from module constructor
+    // ---------------------------------------------------------------
+    template<typename ModuleT>
+    void configureParams(ModuleT* module) {
+        const auto& sr = EuclogicConstants::speedRatios();
+        const auto& sl = EuclogicConstants::speedLabels();
+        const auto& qr = EuclogicConstants::quantRatios();
+        const auto& ql = EuclogicConstants::quantLabels();
+
+        module->configSwitch(ModuleT::MASTER_SPEED_PARAM, 0.f, sr.size() - 1, 8.f,
+            "Master Speed", sl);
+        module->configParam(ModuleT::SWING_PARAM, 50.f, 75.f, 50.f, "Swing", "%");
+
+        module->configButton(ModuleT::RANDOM_PARAM, "Random");
+        module->configButton(ModuleT::MUTATE_PARAM, "Mutate");
+        module->configButton(ModuleT::UNDO_PARAM, "Undo");
+        module->configButton(ModuleT::REDO_PARAM, "Redo");
+
+        for (int i = 0; i < N; i++) {
+            std::string ch = "Ch " + std::to_string(i + 1);
+
+            module->configParam(ModuleT::STEPS_PARAM + i, 1.f, 64.f, 16.f, ch + " Steps");
+            module->paramQuantities[ModuleT::STEPS_PARAM + i]->snapEnabled = true;
+
+            module->configParam(ModuleT::HITS_PARAM + i, 0.f, 64.f, 8.f, ch + " Hits");
+            module->paramQuantities[ModuleT::HITS_PARAM + i]->snapEnabled = true;
+
+            // Replace with custom quantity that limits to steps
+            auto* hitsQ = new EuclogicHitsParamQuantity<ModuleT>();
+            hitsQ->channel = i;
+            hitsQ->module = module;
+            hitsQ->paramId = ModuleT::HITS_PARAM + i;
+            hitsQ->minValue = 0.f;
+            hitsQ->maxValue = 64.f;
+            hitsQ->defaultValue = 8.f;
+            hitsQ->name = ch + " Hits";
+            hitsQ->snapEnabled = true;
+            delete module->paramQuantities[ModuleT::HITS_PARAM + i];
+            module->paramQuantities[ModuleT::HITS_PARAM + i] = hitsQ;
+
+            module->configSwitch(ModuleT::QUANT_PARAM + i, 0.f, qr.size() - 1, 0.f,
+                ch + " Quant", ql);
+
+            module->configParam(ModuleT::PROB_A_PARAM + i, 0.f, 1.f, 1.f, ch + " Prob A", "%", 0.f, 100.f);
+            module->configParam(ModuleT::PROB_B_PARAM + i, 0.f, 1.f, 1.f, ch + " Prob B", "%", 0.f, 100.f);
+            module->configSwitch(ModuleT::RETRIG_PARAM + i, 0.f, 1.f, 1.f, ch + " Retrigger", {"Off", "On"});
+
+            module->configInput(ModuleT::HITS_CV_INPUT + i, ch + " Hits CV");
+            module->configInput(ModuleT::PROB_A_CV_INPUT + i, ch + " Prob A CV");
+            module->configInput(ModuleT::PROB_B_CV_INPUT + i, ch + " Prob B CV");
+
+            module->configOutput(ModuleT::GATE_OUTPUT + i, ch + " Gate");
+            module->configOutput(ModuleT::TRIG_OUTPUT + i, ch + " Trigger");
+            module->configOutput(ModuleT::LFO_OUTPUT + i, ch + " LFO");
+
+            if (HAS_PRE_GATE) {
+                module->configOutput(ModuleT::PRE_GATE_OUTPUT + i, ch + " Pre-Logic Gate");
+            }
+        }
+
+        module->configInput(ModuleT::CLOCK_INPUT, "Clock");
+        module->configInput(ModuleT::RESET_INPUT, "Reset");
+        module->configInput(ModuleT::RUN_INPUT, "Run");
+
+        module->configLight(ModuleT::CLOCK_LIGHT, "Clock Lock");
+        module->configLight(ModuleT::RUN_LIGHT, "Running");
+    }
+
+    // ---------------------------------------------------------------
+    // resetState — called from module onReset()
+    // ---------------------------------------------------------------
+    void resetState() {
+        for (int i = 0; i < N; i++) {
+            engines[i].reset();
+            quantCounter[i] = 0;
+            gateStates[i].store(false);
+            preGateStates[i].store(false);
+            prevGateHigh[i] = false;
+            retrigGapTimer[i] = 0.f;
+        }
+        timeSinceClock = 0.f;
+        internalTickPhase = 0.f;
+        clockPeriod = EuclogicConstants::DEFAULT_CLOCK_PERIOD;
+        running = true;
+        hadFirstTick = false;
+        prevSpeedIdx = 8;  // x1
+        swingLong = true;
+        currentInputState.store(0);
+    }
+
+    // ---------------------------------------------------------------
+    // process — the main audio-rate processing
+    // ---------------------------------------------------------------
+    template<typename ModuleT>
+    void process(ModuleT* module, float dt) {
+        // Handle reset
+        if (resetTrigger.process(module->inputs[ModuleT::RESET_INPUT].getVoltage(), EuclogicConstants::SCHMITT_LOW, EuclogicConstants::SCHMITT_HIGH)) {
+            resetState();
+        }
+
+        // Handle run gate
+        if (module->inputs[ModuleT::RUN_INPUT].isConnected()) {
+            running = module->inputs[ModuleT::RUN_INPUT].getVoltage() > EuclogicConstants::SCHMITT_HIGH;
+        } else {
+            running = true;
+        }
+        module->lights[ModuleT::RUN_LIGHT].setBrightness(running ? 1.f : 0.2f);
+
+        // Handle buttons
+        if (randomTrigger.process(module->params[ModuleT::RANDOM_PARAM].getValue())) {
+            truthTable.randomize();
+        }
+        if (mutateTrigger.process(module->params[ModuleT::MUTATE_PARAM].getValue())) {
+            truthTable.mutate();
+        }
+        if (undoTrigger.process(module->params[ModuleT::UNDO_PARAM].getValue())) {
+            truthTable.undo();
+        }
+        if (redoTrigger.process(module->params[ModuleT::REDO_PARAM].getValue())) {
+            truthTable.redo();
+        }
+
+        // Clock handling - measure period
+        timeSinceClock += dt;
+
+        bool clockEdge = false;
+        if (clockTrigger.process(module->inputs[ModuleT::CLOCK_INPUT].getVoltage(), EuclogicConstants::SCHMITT_LOW, EuclogicConstants::SCHMITT_HIGH)) {
+            if (timeSinceClock > 0.001f) {
+                clockPeriod = timeSinceClock;
+                clockLocked = true;
+            }
+            timeSinceClock = 0.f;
+            clockEdge = true;
+        }
+
+        // Clock timeout
+        if (timeSinceClock > 2.f) {
+            clockLocked = false;
+            hadFirstTick = false;
+        }
+        module->lights[ModuleT::CLOCK_LIGHT].setBrightness(clockLocked ? 1.f : 0.2f);
+
+        // Get master speed ratio
+        const auto& speedRatios = EuclogicConstants::speedRatios();
+        int speedIdx = static_cast<int>(module->params[ModuleT::MASTER_SPEED_PARAM].getValue());
+        speedIdx = DSP::clamp(speedIdx, 0, (int)speedRatios.size() - 1);
+        float masterSpeed = speedRatios[speedIdx];
+
+        // Detect speed change - resync on next clock edge
+        if (speedIdx != prevSpeedIdx) {
+            hadFirstTick = false;
+            internalTickPhase = 0.f;
+            prevSpeedIdx = speedIdx;
+        }
+
+        // Get swing amount (50% = even, 66% = triplet, 75% = hard swing)
+        float swingPercent = module->params[ModuleT::SWING_PARAM].getValue();
+        float swingRatio = swingPercent / 100.f;
+
+        // Determine if we should tick
+        bool shouldTick = false;
+        if (running && clockLocked) {
+            float baseInterval = clockPeriod / masterSpeed;
+            float longInterval = 2.f * baseInterval * swingRatio;
+            float shortInterval = 2.f * baseInterval * (1.f - swingRatio);
+            float currentInterval = swingLong ? longInterval : shortInterval;
+
+            if (clockEdge) {
+                shouldTick = true;
+                hadFirstTick = true;
+                swingLong = true;
+                internalTickPhase = 0.f;
+            } else if (hadFirstTick) {
+                internalTickPhase += dt;
+                if (internalTickPhase >= currentInterval) {
+                    internalTickPhase -= currentInterval;
+                    shouldTick = true;
+                    swingLong = !swingLong;
+                }
+            }
+        }
+
+        // Process tick
+        if (shouldTick) {
+            processTickImpl(module);
+        }
+
+        // Output voltages
+        updateOutputs(module, dt);
+
+        // Update LED matrix
+        updateLEDs(module);
+    }
+
+private:
+    // ---------------------------------------------------------------
+    // processTickImpl — per-tick: euclidean engines + truth table + probability
+    // ---------------------------------------------------------------
+    template<typename ModuleT>
+    void processTickImpl(ModuleT* module) {
+        const auto& quantRatios = EuclogicConstants::quantRatios();
+
+        bool preLogicStates[N] = {};
+
+        for (int i = 0; i < N; i++) {
+            int quantIdx = static_cast<int>(module->params[ModuleT::QUANT_PARAM + i].getValue());
+            quantIdx = DSP::clamp(quantIdx, 0, (int)quantRatios.size() - 1);
+            float quantRatio = quantRatios[quantIdx];
+
+            int divAmount = static_cast<int>(1.f / quantRatio);
+            if (divAmount < 1) divAmount = 1;
+
+            quantCounter[i]++;
+            if (quantCounter[i] >= divAmount) {
+                quantCounter[i] = 0;
+
+                int steps = static_cast<int>(module->params[ModuleT::STEPS_PARAM + i].getValue());
+                float hitsBase = module->params[ModuleT::HITS_PARAM + i].getValue();
+                float hitsCV = module->inputs[ModuleT::HITS_CV_INPUT + i].getVoltage() / 5.f * 12.f;
+                int hits = static_cast<int>(hitsBase + hitsCV);
+                hits = DSP::clamp(hits, 0, steps);
+
+                engines[i].configure(steps, hits, 0);
+                bool euclideanHit = engines[i].tick();
+
+                float probABase = module->params[ModuleT::PROB_A_PARAM + i].getValue();
+                float probACV = module->inputs[ModuleT::PROB_A_CV_INPUT + i].getVoltage() / 10.f;
+                float probAVal = DSP::clamp(probABase + probACV, 0.f, 1.f);
+
+                preLogicStates[i] = euclideanHit && probA[i].process(true, probAVal);
+            } else {
+                preLogicStates[i] = false;
+            }
+        }
+
+        // Store pre-logic gate states for output
+        for (int i = 0; i < N; i++) {
+            preGateStates[i].store(preLogicStates[i]);
+        }
+
+        // Build input state for truth table
+        uint8_t inputState = 0;
+        for (int i = 0; i < N; i++) {
+            if (preLogicStates[i]) inputState |= (1 << i);
+        }
+        currentInputState.store(inputState);
+
+        // Apply truth table
+        bool postLogicStates[N];
+        truthTable.evaluate(preLogicStates, postLogicStates);
+
+        // Apply Probability B and generate gate/trigger outputs
+        for (int i = 0; i < N; i++) {
+            float probBBase = module->params[ModuleT::PROB_B_PARAM + i].getValue();
+            float probBCV = module->inputs[ModuleT::PROB_B_CV_INPUT + i].getVoltage() / 10.f;
+            float probBVal = DSP::clamp(probBBase + probBCV, 0.f, 1.f);
+
+            bool finalOutput = postLogicStates[i] && probB[i].process(true, probBVal);
+            bool retrigger = module->params[ModuleT::RETRIG_PARAM + i].getValue() > 0.5f;
+
+            bool shouldTrigger = finalOutput && (!prevGateHigh[i] || retrigger);
+            if (shouldTrigger) {
+                trigPulse[i].trigger(EuclogicConstants::TRIGGER_PULSE_DURATION);
+            }
+
+            if (finalOutput && prevGateHigh[i] && retrigger) {
+                retrigGapTimer[i] = EuclogicConstants::RETRIG_GAP_DURATION;
+            }
+
+            gateStates[i].store(finalOutput);
+            prevGateHigh[i] = finalOutput;
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // updateOutputs — write voltages to output ports
+    // ---------------------------------------------------------------
+    template<typename ModuleT>
+    void updateOutputs(ModuleT* module, float dt) {
+        for (int i = 0; i < N; i++) {
+            bool gate = gateStates[i].load();
+
+            // Handle retrigger gap
+            if (retrigGapTimer[i] > 0.f) {
+                retrigGapTimer[i] -= dt;
+                module->outputs[ModuleT::GATE_OUTPUT + i].setVoltage(0.f);
+            } else {
+                module->outputs[ModuleT::GATE_OUTPUT + i].setVoltage(gate ? 10.f : 0.f);
+            }
+
+            module->outputs[ModuleT::TRIG_OUTPUT + i].setVoltage(trigPulse[i].process(dt) ? 10.f : 0.f);
+            module->lights[ModuleT::GATE_LIGHT + i].setBrightness(gate ? 1.f : 0.f);
+
+            // LFO output: unipolar ramp 0-10V tracking step position
+            // Fix for issue #21: use (steps-1) so phase reaches full 1.0
+            int steps = engines[i].steps;
+            int currentStep = engines[i].currentStep;
+            float phase = (steps > 1) ? (float)currentStep / (float)(steps - 1) : 0.f;
+            module->outputs[ModuleT::LFO_OUTPUT + i].setVoltage(phase * 10.f);
+
+            // Pre-logic gate output (before truth table)
+            if (HAS_PRE_GATE) {
+                bool preGate = preGateStates[i].load();
+                module->outputs[ModuleT::PRE_GATE_OUTPUT + i].setVoltage(preGate ? 10.f : 0.f);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // updateLEDs — refresh truth table LED matrix
+    // ---------------------------------------------------------------
+    template<typename ModuleT>
+    void updateLEDs(ModuleT* module) {
+        constexpr int N_STATES = (1 << N);
+        uint8_t currentState = currentInputState.load();
+        for (int state = 0; state < N_STATES; state++) {
+            uint8_t outputMask = truthTable.getMapping(state);
+            bool isCurrentState = (state == currentState);
+            for (int bit = 0; bit < N; bit++) {
+                bool isSet = (outputMask >> bit) & 1;
+                float brightness = isSet ? (isCurrentState ? 1.f : 0.5f) : (isCurrentState ? 0.2f : 0.05f);
+                module->lights[ModuleT::LED_MATRIX_LIGHT + state * N + bit].setBrightness(brightness);
+            }
+        }
+    }
+
+public:
+    // ---------------------------------------------------------------
+    // JSON serialization
+    // ---------------------------------------------------------------
+    json_t* dataToJson() const {
+        json_t* rootJ = json_object();
+        json_object_set_new(rootJ, "clockPeriod", json_real(clockPeriod));
+
+        json_t* mappingJ = json_array();
+        auto mapping = truthTable.serialize();
+        for (int i = 0; i < TruthTableT<N>::N_STATES; i++) {
+            json_array_append_new(mappingJ, json_integer(mapping[i]));
+        }
+        json_object_set_new(rootJ, "truthTable", mappingJ);
+
+        return rootJ;
+    }
+
+    void dataFromJson(json_t* rootJ) {
+        json_t* periodJ = json_object_get(rootJ, "clockPeriod");
+        if (periodJ) {
+            clockPeriod = json_real_value(periodJ);
+        }
+
+        json_t* mappingJ = json_object_get(rootJ, "truthTable");
+        if (mappingJ && json_is_array(mappingJ)) {
+            std::array<uint8_t, TruthTableT<N>::N_STATES> mapping{};
+            for (int i = 0; i < TruthTableT<N>::N_STATES && i < (int)json_array_size(mappingJ); i++) {
+                mapping[i] = json_integer_value(json_array_get(mappingJ, i));
+            }
+            truthTable.deserialize(mapping);
+        }
+    }
+};
+
+} // namespace WiggleRoom

--- a/src/modules/Euclogic2/Euclogic2.cpp
+++ b/src/modules/Euclogic2/Euclogic2.cpp
@@ -3,138 +3,27 @@
  * 2-channel Euclidean drum sequencer with truth table logic (compact version)
  *
  * Signal flow:
- *   Clock → Master Speed → 2x Euclidean Engines → Prob A → Truth Table → Prob B → Outputs
+ *   Clock -> Master Speed -> 2x Euclidean Engines -> Prob A -> Truth Table -> Prob B -> Outputs
  *
  * Features:
  *   - 2 independent Euclidean rhythm generators
  *   - Per-channel: Steps (1-64), Hits (0-Steps), Quant ratio
- *   - Probability A: Pre-logic probability gate (×2)
+ *   - Probability A: Pre-logic probability gate (x2)
  *   - Truth Table: 4-state logic engine with LED matrix display
- *   - Probability B: Post-logic probability gate (×2)
+ *   - Probability B: Post-logic probability gate (x2)
  *   - Random/Mutate/Undo buttons for truth table
- *   - 2x Gate + 2x Trigger + 2x LFO outputs
+ *   - 2x Gate + 2x Trigger + 2x LFO + 2x Pre-Gate outputs
  ******************************************************************************/
 
-#include "rack.hpp"
-#include "DSP.hpp"
+#include "EuclogicCore.hpp"
 #include "ImagePanel.hpp"
-#include "EuclideanEngine.hpp"
-#include "ProbabilityGate.hpp"
-#include <atomic>
-#include <array>
-#include <random>
-
-using namespace rack;
 
 extern Plugin* pluginInstance;
 
 namespace WiggleRoom {
 
-// Speed ratio values (/16 to x16)
-static const std::vector<float> SPEED_RATIOS_2 = {
-    1.f/16, 1.f/12, 1.f/8, 1.f/6, 1.f/4, 1.f/3, 1.f/2, 2.f/3,
-    1.f,  // x1 (index 8)
-    3.f/2, 2.f, 3.f, 4.f, 6.f, 8.f, 12.f, 16.f
-};
-
-static const std::vector<std::string> SPEED_LABELS_2 = {
-    "/16", "/12", "/8", "/6", "/4", "/3", "/2", "/1.5",
-    "x1",
-    "x1.5", "x2", "x3", "x4", "x6", "x8", "x12", "x16"
-};
-
-// Quant ratio values (per-channel clock division)
-static const std::vector<float> QUANT_RATIOS_2 = {
-    1.f, 1.f/2, 1.f/4, 1.f/8, 1.f/16
-};
-
-static const std::vector<std::string> QUANT_LABELS_2 = {
-    "x1", "/2", "/4", "/8", "/16"
-};
-
-// Forward declaration
-struct Euclogic2;
-
-// Simple 2-input truth table (4 states)
-struct TruthTable2 {
-    std::array<uint8_t, 4> mapping = {0, 1, 2, 3};  // Default: pass-through
-    std::vector<std::array<uint8_t, 4>> undoHistory;
-    std::vector<std::array<uint8_t, 4>> redoHistory;
-    std::mt19937 rng{std::random_device{}()};
-
-    void randomize() {
-        pushUndo();
-        std::uniform_int_distribution<int> dist(0, 3);
-        for (int i = 0; i < 4; i++) {
-            mapping[i] = dist(rng);
-        }
-    }
-
-    void mutate() {
-        pushUndo();
-        std::uniform_int_distribution<int> stateDist(0, 3);
-        std::uniform_int_distribution<int> bitDist(0, 1);
-        int state = stateDist(rng);
-        int bit = bitDist(rng);
-        mapping[state] ^= (1 << bit);
-    }
-
-    void pushUndo() {
-        undoHistory.push_back(mapping);
-        redoHistory.clear();
-    }
-
-    bool undo() {
-        if (undoHistory.empty()) return false;
-        redoHistory.push_back(mapping);
-        mapping = undoHistory.back();
-        undoHistory.pop_back();
-        return true;
-    }
-
-    bool redo() {
-        if (redoHistory.empty()) return false;
-        undoHistory.push_back(mapping);
-        mapping = redoHistory.back();
-        redoHistory.pop_back();
-        return true;
-    }
-
-    void toggleBit(int state, int bit) {
-        if (state >= 0 && state < 4 && bit >= 0 && bit < 2) {
-            mapping[state] ^= (1 << bit);
-        }
-    }
-
-    uint8_t getMapping(int state) const {
-        return (state >= 0 && state < 4) ? mapping[state] : 0;
-    }
-
-    void evaluate(const bool* inputs, bool* outputs) const {
-        uint8_t inputState = (inputs[0] ? 1 : 0) | (inputs[1] ? 2 : 0);
-        uint8_t outputMask = mapping[inputState];
-        outputs[0] = (outputMask >> 0) & 1;
-        outputs[1] = (outputMask >> 1) & 1;
-    }
-
-    std::array<uint8_t, 4> serialize() const { return mapping; }
-    void deserialize(const std::array<uint8_t, 4>& m) { mapping = m; }
-};
-
-// Custom ParamQuantity that limits hits to current steps value
-struct Hits2ParamQuantity : ParamQuantity {
-    int channel = 0;
-    float getMaxValue() override;
-    void setValue(float value) override;
-};
-
 struct Euclogic2 : Module {
     static constexpr int NUM_CHANNELS = 2;
-    static constexpr float TRIGGER_PULSE_DURATION = 1e-3f;  // 1ms
-    static constexpr float RETRIG_GAP_DURATION = 0.5e-3f;   // 0.5ms gap for retrigger
-    static constexpr float SCHMITT_LOW = 0.1f;
-    static constexpr float SCHMITT_HIGH = 1.0f;
-    static constexpr float DEFAULT_CLOCK_PERIOD = 0.5f;  // 120 BPM
 
     enum ParamId {
         MASTER_SPEED_PARAM,
@@ -166,7 +55,7 @@ struct Euclogic2 : Module {
         ENUMS(GATE_OUTPUT, NUM_CHANNELS),
         ENUMS(TRIG_OUTPUT, NUM_CHANNELS),
         ENUMS(LFO_OUTPUT, NUM_CHANNELS),
-        ENUMS(PRE_GATE_OUTPUT, NUM_CHANNELS),  // Pre-logic gate outputs
+        ENUMS(PRE_GATE_OUTPUT, NUM_CHANNELS),
         OUTPUTS_LEN
     };
 
@@ -174,358 +63,33 @@ struct Euclogic2 : Module {
         CLOCK_LIGHT,
         RUN_LIGHT,
         ENUMS(GATE_LIGHT, NUM_CHANNELS),
-        ENUMS(LED_MATRIX_LIGHT, 8),  // 4 input states × 2 output bits
+        ENUMS(LED_MATRIX_LIGHT, 8),  // 4 input states x 2 output bits
         LIGHTS_LEN
     };
 
-    // Core components
-    EuclideanEngine engines[NUM_CHANNELS];
-    ProbabilityGate probA[NUM_CHANNELS];
-    ProbabilityGate probB[NUM_CHANNELS];
-    TruthTable2 truthTable;
-
-    // Clock state
-    dsp::SchmittTrigger clockTrigger;
-    dsp::SchmittTrigger resetTrigger;
-    dsp::SchmittTrigger runTrigger;
-    dsp::SchmittTrigger randomTrigger;
-    dsp::SchmittTrigger mutateTrigger;
-    dsp::SchmittTrigger undoTrigger;
-    dsp::SchmittTrigger redoTrigger;
-
-    float clockPeriod = DEFAULT_CLOCK_PERIOD;
-    float timeSinceClock = 0.f;
-    float internalTickPhase = 0.f;
-    bool clockLocked = false;
-    bool running = true;
-    bool hadFirstTick = false;
-    int prevSpeedIdx = 8;
-    bool swingLong = true;
-
-    int quantCounter[NUM_CHANNELS] = {0};
-    dsp::PulseGenerator trigPulse[NUM_CHANNELS];
-    bool prevGateHigh[NUM_CHANNELS] = {false};
-    float retrigGapTimer[NUM_CHANNELS] = {0.f};
-
-    std::atomic<uint8_t> currentInputState{0};
-    std::atomic<bool> gateStates[NUM_CHANNELS];
-    std::atomic<bool> preGateStates[NUM_CHANNELS];
+    EuclogicCore<2, true> core;
 
     Euclogic2() {
         config(PARAMS_LEN, INPUTS_LEN, OUTPUTS_LEN, LIGHTS_LEN);
-
-        configSwitch(MASTER_SPEED_PARAM, 0.f, SPEED_RATIOS_2.size() - 1, 8.f,
-            "Master Speed", SPEED_LABELS_2);
-        configParam(SWING_PARAM, 50.f, 75.f, 50.f, "Swing", "%");
-
-        configButton(RANDOM_PARAM, "Random");
-        configButton(MUTATE_PARAM, "Mutate");
-        configButton(UNDO_PARAM, "Undo");
-        configButton(REDO_PARAM, "Redo");
-
-        for (int i = 0; i < NUM_CHANNELS; i++) {
-            std::string ch = "Ch " + std::to_string(i + 1);
-
-            configParam(STEPS_PARAM + i, 1.f, 64.f, 16.f, ch + " Steps");
-            paramQuantities[STEPS_PARAM + i]->snapEnabled = true;
-
-            configParam(HITS_PARAM + i, 0.f, 64.f, 8.f, ch + " Hits");
-            paramQuantities[HITS_PARAM + i]->snapEnabled = true;
-            Hits2ParamQuantity* hitsQ = new Hits2ParamQuantity();
-            hitsQ->channel = i;
-            hitsQ->module = this;
-            hitsQ->paramId = HITS_PARAM + i;
-            hitsQ->minValue = 0.f;
-            hitsQ->maxValue = 64.f;
-            hitsQ->defaultValue = 8.f;
-            hitsQ->name = ch + " Hits";
-            hitsQ->snapEnabled = true;
-            delete paramQuantities[HITS_PARAM + i];
-            paramQuantities[HITS_PARAM + i] = hitsQ;
-
-            configSwitch(QUANT_PARAM + i, 0.f, QUANT_RATIOS_2.size() - 1, 0.f,
-                ch + " Quant", QUANT_LABELS_2);
-
-            configParam(PROB_A_PARAM + i, 0.f, 1.f, 1.f, ch + " Prob A", "%", 0.f, 100.f);
-            configParam(PROB_B_PARAM + i, 0.f, 1.f, 1.f, ch + " Prob B", "%", 0.f, 100.f);
-            configSwitch(RETRIG_PARAM + i, 0.f, 1.f, 1.f, ch + " Retrigger", {"Off", "On"});
-
-            configInput(HITS_CV_INPUT + i, ch + " Hits CV");
-            configInput(PROB_A_CV_INPUT + i, ch + " Prob A CV");
-            configInput(PROB_B_CV_INPUT + i, ch + " Prob B CV");
-
-            configOutput(GATE_OUTPUT + i, ch + " Gate");
-            configOutput(TRIG_OUTPUT + i, ch + " Trigger");
-            configOutput(LFO_OUTPUT + i, ch + " LFO");
-            configOutput(PRE_GATE_OUTPUT + i, ch + " Pre-Logic Gate");
-        }
-
-        configInput(CLOCK_INPUT, "Clock");
-        configInput(RESET_INPUT, "Reset");
-        configInput(RUN_INPUT, "Run");
-
-        configLight(CLOCK_LIGHT, "Clock Lock");
-        configLight(RUN_LIGHT, "Running");
-
-        // Initialize engines with default values
-        for (int i = 0; i < NUM_CHANNELS; i++) {
-            engines[i].configure(16, 8, 0);  // 16 steps, 8 hits
-            gateStates[i].store(false);
-            preGateStates[i].store(false);
-        }
+        core.configureParams(this);
     }
 
     void onReset() override {
-        for (int i = 0; i < NUM_CHANNELS; i++) {
-            engines[i].reset();
-            quantCounter[i] = 0;
-            gateStates[i].store(false);
-            preGateStates[i].store(false);
-            prevGateHigh[i] = false;
-            retrigGapTimer[i] = 0.f;
-        }
-        timeSinceClock = 0.f;
-        internalTickPhase = 0.f;
-        clockPeriod = DEFAULT_CLOCK_PERIOD;
-        running = true;
-        hadFirstTick = false;
-        prevSpeedIdx = 8;
-        swingLong = true;
-        currentInputState.store(0);
+        core.resetState();
     }
 
     void process(const ProcessArgs& args) override {
-        float dt = args.sampleTime;
-
-        if (resetTrigger.process(inputs[RESET_INPUT].getVoltage(), SCHMITT_LOW, SCHMITT_HIGH)) {
-            onReset();
-        }
-
-        if (inputs[RUN_INPUT].isConnected()) {
-            running = inputs[RUN_INPUT].getVoltage() > SCHMITT_HIGH;
-        } else {
-            running = true;
-        }
-        lights[RUN_LIGHT].setBrightness(running ? 1.f : 0.2f);
-
-        if (randomTrigger.process(params[RANDOM_PARAM].getValue())) {
-            truthTable.randomize();
-        }
-        if (mutateTrigger.process(params[MUTATE_PARAM].getValue())) {
-            truthTable.mutate();
-        }
-        if (undoTrigger.process(params[UNDO_PARAM].getValue())) {
-            truthTable.undo();
-        }
-        if (redoTrigger.process(params[REDO_PARAM].getValue())) {
-            truthTable.redo();
-        }
-
-        timeSinceClock += dt;
-
-        bool clockEdge = false;
-        if (clockTrigger.process(inputs[CLOCK_INPUT].getVoltage(), SCHMITT_LOW, SCHMITT_HIGH)) {
-            if (timeSinceClock > 0.001f) {
-                clockPeriod = timeSinceClock;
-                clockLocked = true;
-            }
-            timeSinceClock = 0.f;
-            clockEdge = true;
-        }
-
-        if (timeSinceClock > 2.f) {
-            clockLocked = false;
-            hadFirstTick = false;
-        }
-        lights[CLOCK_LIGHT].setBrightness(clockLocked ? 1.f : 0.2f);
-
-        int speedIdx = static_cast<int>(params[MASTER_SPEED_PARAM].getValue());
-        speedIdx = DSP::clamp(speedIdx, 0, (int)SPEED_RATIOS_2.size() - 1);
-        float masterSpeed = SPEED_RATIOS_2[speedIdx];
-
-        if (speedIdx != prevSpeedIdx) {
-            hadFirstTick = false;
-            internalTickPhase = 0.f;
-            prevSpeedIdx = speedIdx;
-        }
-
-        float swingPercent = params[SWING_PARAM].getValue();
-        float swingRatio = swingPercent / 100.f;
-
-        bool shouldTick = false;
-        if (running && clockLocked) {
-            float baseInterval = clockPeriod / masterSpeed;
-            float longInterval = 2.f * baseInterval * swingRatio;
-            float shortInterval = 2.f * baseInterval * (1.f - swingRatio);
-            float currentInterval = swingLong ? longInterval : shortInterval;
-
-            if (clockEdge) {
-                shouldTick = true;
-                hadFirstTick = true;
-                swingLong = true;
-                internalTickPhase = 0.f;
-            } else if (hadFirstTick) {
-                internalTickPhase += dt;
-                if (internalTickPhase >= currentInterval) {
-                    internalTickPhase -= currentInterval;
-                    shouldTick = true;
-                    swingLong = !swingLong;
-                }
-            }
-        }
-
-        if (shouldTick) {
-            bool preLogicStates[NUM_CHANNELS] = {false};
-
-            for (int i = 0; i < NUM_CHANNELS; i++) {
-                int quantIdx = static_cast<int>(params[QUANT_PARAM + i].getValue());
-                quantIdx = DSP::clamp(quantIdx, 0, (int)QUANT_RATIOS_2.size() - 1);
-                float quantRatio = QUANT_RATIOS_2[quantIdx];
-
-                int divAmount = static_cast<int>(1.f / quantRatio);
-                if (divAmount < 1) divAmount = 1;
-
-                quantCounter[i]++;
-                if (quantCounter[i] >= divAmount) {
-                    quantCounter[i] = 0;
-
-                    int steps = static_cast<int>(params[STEPS_PARAM + i].getValue());
-                    float hitsBase = params[HITS_PARAM + i].getValue();
-                    float hitsCV = inputs[HITS_CV_INPUT + i].getVoltage() / 5.f * 12.f;
-                    int hits = static_cast<int>(hitsBase + hitsCV);
-                    hits = DSP::clamp(hits, 0, steps);
-
-                    engines[i].configure(steps, hits, 0);
-                    bool euclideanHit = engines[i].tick();
-
-                    float probABase = params[PROB_A_PARAM + i].getValue();
-                    float probACV = inputs[PROB_A_CV_INPUT + i].getVoltage() / 10.f;
-                    float probAVal = DSP::clamp(probABase + probACV, 0.f, 1.f);
-
-                    preLogicStates[i] = euclideanHit && probA[i].process(true, probAVal);
-                } else {
-                    preLogicStates[i] = false;
-                }
-            }
-
-            // Store pre-logic gate states for output
-            for (int i = 0; i < NUM_CHANNELS; i++) {
-                preGateStates[i].store(preLogicStates[i]);
-            }
-
-            uint8_t inputState = (preLogicStates[0] ? 1 : 0) | (preLogicStates[1] ? 2 : 0);
-            currentInputState.store(inputState);
-
-            bool postLogicStates[NUM_CHANNELS];
-            truthTable.evaluate(preLogicStates, postLogicStates);
-
-            for (int i = 0; i < NUM_CHANNELS; i++) {
-                float probBBase = params[PROB_B_PARAM + i].getValue();
-                float probBCV = inputs[PROB_B_CV_INPUT + i].getVoltage() / 10.f;
-                float probBVal = DSP::clamp(probBBase + probBCV, 0.f, 1.f);
-
-                bool finalOutput = postLogicStates[i] && probB[i].process(true, probBVal);
-                bool retrigger = params[RETRIG_PARAM + i].getValue() > 0.5f;
-
-                bool shouldTrigger = finalOutput && (!prevGateHigh[i] || retrigger);
-                if (shouldTrigger) {
-                    trigPulse[i].trigger(TRIGGER_PULSE_DURATION);
-                }
-
-                // Start retrigger gap if we have consecutive hits with retrigger on
-                if (finalOutput && prevGateHigh[i] && retrigger) {
-                    retrigGapTimer[i] = RETRIG_GAP_DURATION;
-                }
-
-                gateStates[i].store(finalOutput);
-                prevGateHigh[i] = finalOutput;
-            }
-        }
-
-        // Output voltages
-        for (int i = 0; i < NUM_CHANNELS; i++) {
-            bool gate = gateStates[i].load();
-
-            // Handle retrigger gap - force gate low briefly for envelope retrigger
-            if (retrigGapTimer[i] > 0.f) {
-                retrigGapTimer[i] -= dt;
-                outputs[GATE_OUTPUT + i].setVoltage(0.f);
-            } else {
-                outputs[GATE_OUTPUT + i].setVoltage(gate ? 10.f : 0.f);
-            }
-
-            outputs[TRIG_OUTPUT + i].setVoltage(trigPulse[i].process(dt) ? 10.f : 0.f);
-            lights[GATE_LIGHT + i].setBrightness(gate ? 1.f : 0.f);
-
-            // LFO output: unipolar ramp 0-10V tracking step position
-            int steps = engines[i].steps;
-            int currentStep = engines[i].currentStep;
-            float phase = (steps > 1) ? (float)currentStep / (float)(steps - 1) : 0.f;
-            outputs[LFO_OUTPUT + i].setVoltage(phase * 10.f);
-
-            // Pre-logic gate output (before truth table)
-            bool preGate = preGateStates[i].load();
-            outputs[PRE_GATE_OUTPUT + i].setVoltage(preGate ? 10.f : 0.f);
-        }
-
-        // Update LED matrix lights (4 states × 2 outputs)
-        uint8_t currentState = currentInputState.load();
-        for (int state = 0; state < 4; state++) {
-            uint8_t outputMask = truthTable.getMapping(state);
-            bool isCurrentState = (state == currentState);
-            for (int bit = 0; bit < 2; bit++) {
-                bool isSet = (outputMask >> bit) & 1;
-                float brightness = isSet ? (isCurrentState ? 1.f : 0.5f) : (isCurrentState ? 0.2f : 0.05f);
-                lights[LED_MATRIX_LIGHT + state * 2 + bit].setBrightness(brightness);
-            }
-        }
+        core.process(this, args.sampleTime);
     }
 
     json_t* dataToJson() override {
-        json_t* rootJ = json_object();
-        json_object_set_new(rootJ, "clockPeriod", json_real(clockPeriod));
-
-        json_t* mappingJ = json_array();
-        auto mapping = truthTable.serialize();
-        for (int i = 0; i < 4; i++) {
-            json_array_append_new(mappingJ, json_integer(mapping[i]));
-        }
-        json_object_set_new(rootJ, "truthTable", mappingJ);
-
-        return rootJ;
+        return core.dataToJson();
     }
 
     void dataFromJson(json_t* rootJ) override {
-        json_t* periodJ = json_object_get(rootJ, "clockPeriod");
-        if (periodJ) {
-            clockPeriod = json_real_value(periodJ);
-        }
-
-        json_t* mappingJ = json_object_get(rootJ, "truthTable");
-        if (mappingJ && json_is_array(mappingJ)) {
-            std::array<uint8_t, 4> mapping;
-            for (int i = 0; i < 4 && i < (int)json_array_size(mappingJ); i++) {
-                mapping[i] = json_integer_value(json_array_get(mappingJ, i));
-            }
-            truthTable.deserialize(mapping);
-        }
+        core.dataFromJson(rootJ);
     }
 };
-
-// HitsParamQuantity implementation
-float Hits2ParamQuantity::getMaxValue() {
-    Euclogic2* euclogic = dynamic_cast<Euclogic2*>(module);
-    if (euclogic) {
-        int steps = static_cast<int>(euclogic->params[Euclogic2::STEPS_PARAM + channel].getValue());
-        return static_cast<float>(steps);
-    }
-    return 64.f;
-}
-
-void Hits2ParamQuantity::setValue(float value) {
-    value = math::clamp(value, getMinValue(), getMaxValue());
-    ParamQuantity::setValue(value);
-}
 
 // Euclidean Pattern Display - shows 2 channels
 struct Euclidean2Display : LightWidget {
@@ -554,7 +118,7 @@ struct Euclidean2Display : LightWidget {
         }
 
         for (int ch = 0; ch < 2; ch++) {
-            const auto& engine = module->engines[ch];
+            const auto& engine = module->core.engines[ch];
             float y = ch * rowHeight;
             int steps = engine.steps;
             int currentStep = engine.currentStep;
@@ -631,7 +195,7 @@ struct TruthTable2Display : LightWidget {
         nvgFillColor(args.vg, nvgRGBA(15, 15, 25, 160));
         nvgFill(args.vg);
 
-        uint8_t currentState = module ? module->currentInputState.load() : 0;
+        uint8_t currentState = module ? module->core.currentInputState.load() : 0;
 
         for (int state = 0; state < 4; state++) {
             float y = state * rowH;
@@ -644,7 +208,6 @@ struct TruthTable2Display : LightWidget {
                 nvgFill(args.vg);
             }
 
-            // Input columns (A B)
             for (int bit = 0; bit < 2; bit++) {
                 bool bitValue = (state >> (1 - bit)) & 1;
                 float x = bit * singleInputW;
@@ -655,7 +218,6 @@ struct TruthTable2Display : LightWidget {
                 nvgText(args.vg, x + singleInputW / 2.f, y + rowH / 2.f, bitValue ? "T" : "F", nullptr);
             }
 
-            // Separator
             nvgBeginPath(args.vg);
             nvgMoveTo(args.vg, inputColW, y);
             nvgLineTo(args.vg, inputColW, y + rowH);
@@ -663,8 +225,7 @@ struct TruthTable2Display : LightWidget {
             nvgStrokeWidth(args.vg, 1.f);
             nvgStroke(args.vg);
 
-            // Output columns (1 2)
-            uint8_t outputMask = module ? module->truthTable.getMapping(state) : 0;
+            uint8_t outputMask = module ? module->core.truthTable.getMapping(state) : 0;
             for (int outBit = 0; outBit < 2; outBit++) {
                 bool isSet = (outputMask >> outBit) & 1;
                 float x = inputColW + outBit * singleOutputW;
@@ -726,54 +287,43 @@ struct TruthTable2Display : LightWidget {
         int outBit = static_cast<int>((e.pos.x - inputColW) / singleOutputW);
 
         if (row >= 0 && row < 4 && outBit >= 0 && outBit < 2) {
-            module->truthTable.pushUndo();
-            module->truthTable.toggleBit(row, outBit);
+            module->core.truthTable.pushUndo();
+            module->core.truthTable.toggleBit(row, outBit);
             e.consume(this);
         }
-    }
-};
-
-// Snap knob for discrete switch parameters
-struct RoundBlackSnapKnob2 : RoundBlackKnob {
-    RoundBlackSnapKnob2() {
-        snap = true;
     }
 };
 
 struct Euclogic2Widget : ModuleWidget {
     Euclogic2Widget(Euclogic2* module) {
         setModule(module);
-        box.size = Vec(20 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT);  // 20HP
+        box.size = Vec(20 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT);
         addChild(new WiggleRoom::ImagePanel(
             asset::plugin(pluginInstance, "res/Euclogic2.png"), box.size));
 
-        // Screws
         addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH, 0)));
         addChild(createWidget<ScrewSilver>(Vec(box.size.x - 2 * RACK_GRID_WIDTH, 0)));
         addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
         addChild(createWidget<ScrewSilver>(Vec(box.size.x - 2 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-        // Layout: 20HP = 101.6mm wide
         float panelWidth = 101.6f;
 
-        // Top: Euclidean display (y=16-32mm)
         float yEucDisplay = 16.f;
         Euclidean2Display* eucDisplay = createWidget<Euclidean2Display>(mm2px(Vec(4.f, yEucDisplay)));
         eucDisplay->module = module;
         eucDisplay->box.size = mm2px(Vec(panelWidth - 8.f, 16.f));
         addChild(eucDisplay);
 
-        // Channel controls (2 rows)
         float yChannel1 = 36.f;
         float yChannel2 = 48.f;
-        float col1 = 8.f;   // Steps
-        float col2 = 20.f;  // Hits
-        float col3 = 32.f;  // Hits CV
-        float col4 = 44.f;  // Quant
-        float col5 = 56.f;  // Prob A
-        float col6 = 68.f;  // Prob A CV
-        float col7 = 80.f;  // Prob B
-        float col8 = 92.f;  // Prob B CV
+        float col1 = 8.f;
+        float col2 = 20.f;
+        float col3 = 32.f;
+        float col4 = 44.f;
+        float col5 = 56.f;
+        float col6 = 68.f;
+        float col7 = 80.f;
+        float col8 = 92.f;
 
         for (int i = 0; i < Euclogic2::NUM_CHANNELS; i++) {
             float y = (i == 0) ? yChannel1 : yChannel2;
@@ -788,38 +338,32 @@ struct Euclogic2Widget : ModuleWidget {
             addInput(createInputCentered<PJ301MPort>(mm2px(Vec(col8, y)), module, Euclogic2::PROB_B_CV_INPUT + i));
         }
 
-        // Retrigger switches after channel rows
         float yRetrig = 58.f;
         addParam(createParamCentered<CKSS>(mm2px(Vec(col1, yRetrig)), module, Euclogic2::RETRIG_PARAM + 0));
         addParam(createParamCentered<CKSS>(mm2px(Vec(col2, yRetrig)), module, Euclogic2::RETRIG_PARAM + 1));
 
-        // Master clock inputs (same row as retrig)
         addInput(createInputCentered<PJ301MPort>(mm2px(Vec(col5, yRetrig)), module, Euclogic2::CLOCK_INPUT));
         addChild(createLightCentered<SmallLight<GreenLight>>(mm2px(Vec(col5 + 5.f, yRetrig - 4.f)), module, Euclogic2::CLOCK_LIGHT));
         addInput(createInputCentered<PJ301MPort>(mm2px(Vec(col6, yRetrig)), module, Euclogic2::RESET_INPUT));
         addInput(createInputCentered<PJ301MPort>(mm2px(Vec(col7, yRetrig)), module, Euclogic2::RUN_INPUT));
         addChild(createLightCentered<SmallLight<GreenLight>>(mm2px(Vec(col7 + 5.f, yRetrig - 4.f)), module, Euclogic2::RUN_LIGHT));
 
-        // Truth table display (y=68-94mm, positioned on right side)
         float yTable = 68.f;
         TruthTable2Display* truthTable = createWidget<TruthTable2Display>(mm2px(Vec(panelWidth - 54.f, yTable)));
         truthTable->module = module;
         truthTable->box.size = mm2px(Vec(50.f, 26.f));
         addChild(truthTable);
 
-        // Speed and Swing (left side, same row as truth table)
         float ySpeedRow = 78.f;
-        addParam(createParamCentered<RoundBlackSnapKnob2>(mm2px(Vec(col1 + 6.f, ySpeedRow)), module, Euclogic2::MASTER_SPEED_PARAM));
+        addParam(createParamCentered<EuclogicSnapKnob>(mm2px(Vec(col1 + 6.f, ySpeedRow)), module, Euclogic2::MASTER_SPEED_PARAM));
         addParam(createParamCentered<RoundSmallBlackKnob>(mm2px(Vec(col3, ySpeedRow)), module, Euclogic2::SWING_PARAM));
 
-        // Buttons row (below speed knobs)
         float yButtons = 94.f;
         addParam(createParamCentered<VCVButton>(mm2px(Vec(col1, yButtons)), module, Euclogic2::RANDOM_PARAM));
         addParam(createParamCentered<VCVButton>(mm2px(Vec(col2, yButtons)), module, Euclogic2::MUTATE_PARAM));
         addParam(createParamCentered<VCVButton>(mm2px(Vec(col3, yButtons)), module, Euclogic2::UNDO_PARAM));
         addParam(createParamCentered<VCVButton>(mm2px(Vec(col4, yButtons)), module, Euclogic2::REDO_PARAM));
 
-        // Pre-Logic gate outputs
         float yOutputs = 110.f;
         float yPreOutputs = yOutputs - 10.f;
         for (int i = 0; i < Euclogic2::NUM_CHANNELS; i++) {
@@ -827,15 +371,11 @@ struct Euclogic2Widget : ModuleWidget {
             addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(xBase + 36.f, yPreOutputs)), module, Euclogic2::PRE_GATE_OUTPUT + i));
         }
 
-        // Outputs row (bottom)
         for (int i = 0; i < Euclogic2::NUM_CHANNELS; i++) {
             float xBase = 12.f + i * 40.f;
-            // Gate
             addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(xBase, yOutputs)), module, Euclogic2::GATE_OUTPUT + i));
             addChild(createLightCentered<SmallLight<GreenLight>>(mm2px(Vec(xBase, yOutputs - 5)), module, Euclogic2::GATE_LIGHT + i));
-            // Trigger
             addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(xBase + 12.f, yOutputs)), module, Euclogic2::TRIG_OUTPUT + i));
-            // LFO
             addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(xBase + 24.f, yOutputs)), module, Euclogic2::LFO_OUTPUT + i));
         }
     }

--- a/src/modules/Euclogic3/Euclogic3.cpp
+++ b/src/modules/Euclogic3/Euclogic3.cpp
@@ -12,130 +12,18 @@
  *   - Truth Table: 8-state logic engine with LED matrix display
  *   - Probability B: Post-logic probability gate (x3)
  *   - Random/Mutate/Undo buttons for truth table
- *   - 3x Gate + 3x Trigger + 3x LFO outputs
+ *   - 3x Gate + 3x Trigger + 3x LFO + 3x Pre-Gate outputs
  ******************************************************************************/
 
-#include "rack.hpp"
-#include "DSP.hpp"
+#include "EuclogicCore.hpp"
 #include "ImagePanel.hpp"
-#include "EuclideanEngine.hpp"
-#include "ProbabilityGate.hpp"
-#include <atomic>
-#include <array>
-#include <random>
-
-using namespace rack;
 
 extern Plugin* pluginInstance;
 
 namespace WiggleRoom {
 
-// Speed ratio values (/16 to x16)
-static const std::vector<float> SPEED_RATIOS_3 = {
-    1.f/16, 1.f/12, 1.f/8, 1.f/6, 1.f/4, 1.f/3, 1.f/2, 2.f/3,
-    1.f,  // x1 (index 8)
-    3.f/2, 2.f, 3.f, 4.f, 6.f, 8.f, 12.f, 16.f
-};
-
-static const std::vector<std::string> SPEED_LABELS_3 = {
-    "/16", "/12", "/8", "/6", "/4", "/3", "/2", "/1.5",
-    "x1",
-    "x1.5", "x2", "x3", "x4", "x6", "x8", "x12", "x16"
-};
-
-// Quant ratio values (per-channel clock division)
-static const std::vector<float> QUANT_RATIOS_3 = {
-    1.f, 1.f/2, 1.f/4, 1.f/8, 1.f/16
-};
-
-static const std::vector<std::string> QUANT_LABELS_3 = {
-    "x1", "/2", "/4", "/8", "/16"
-};
-
-// Forward declaration
-struct Euclogic3;
-
-// Simple 3-input truth table (8 states)
-struct TruthTable3 {
-    std::array<uint8_t, 8> mapping = {0, 1, 2, 3, 4, 5, 6, 7};  // Default: pass-through
-    std::vector<std::array<uint8_t, 8>> undoHistory;
-    std::vector<std::array<uint8_t, 8>> redoHistory;
-    std::mt19937 rng{std::random_device{}()};
-
-    void randomize() {
-        pushUndo();
-        std::uniform_int_distribution<int> dist(0, 7);
-        for (int i = 0; i < 8; i++) {
-            mapping[i] = dist(rng);
-        }
-    }
-
-    void mutate() {
-        pushUndo();
-        std::uniform_int_distribution<int> stateDist(0, 7);
-        std::uniform_int_distribution<int> bitDist(0, 2);
-        int state = stateDist(rng);
-        int bit = bitDist(rng);
-        mapping[state] ^= (1 << bit);
-    }
-
-    void pushUndo() {
-        undoHistory.push_back(mapping);
-        redoHistory.clear();
-    }
-
-    bool undo() {
-        if (undoHistory.empty()) return false;
-        redoHistory.push_back(mapping);
-        mapping = undoHistory.back();
-        undoHistory.pop_back();
-        return true;
-    }
-
-    bool redo() {
-        if (redoHistory.empty()) return false;
-        undoHistory.push_back(mapping);
-        mapping = redoHistory.back();
-        redoHistory.pop_back();
-        return true;
-    }
-
-    void toggleBit(int state, int bit) {
-        if (state >= 0 && state < 8 && bit >= 0 && bit < 3) {
-            mapping[state] ^= (1 << bit);
-        }
-    }
-
-    uint8_t getMapping(int state) const {
-        return (state >= 0 && state < 8) ? mapping[state] : 0;
-    }
-
-    void evaluate(const bool* inputs, bool* outputs) const {
-        uint8_t inputState = (inputs[0] ? 1 : 0) | (inputs[1] ? 2 : 0) | (inputs[2] ? 4 : 0);
-        uint8_t outputMask = mapping[inputState];
-        outputs[0] = (outputMask >> 0) & 1;
-        outputs[1] = (outputMask >> 1) & 1;
-        outputs[2] = (outputMask >> 2) & 1;
-    }
-
-    std::array<uint8_t, 8> serialize() const { return mapping; }
-    void deserialize(const std::array<uint8_t, 8>& m) { mapping = m; }
-};
-
-// Custom ParamQuantity that limits hits to current steps value
-struct Hits3ParamQuantity : ParamQuantity {
-    int channel = 0;
-    float getMaxValue() override;
-    void setValue(float value) override;
-};
-
 struct Euclogic3 : Module {
     static constexpr int NUM_CHANNELS = 3;
-    static constexpr float TRIGGER_PULSE_DURATION = 1e-3f;  // 1ms
-    static constexpr float RETRIG_GAP_DURATION = 0.5e-3f;   // 0.5ms gap for retrigger
-    static constexpr float SCHMITT_LOW = 0.1f;
-    static constexpr float SCHMITT_HIGH = 1.0f;
-    static constexpr float DEFAULT_CLOCK_PERIOD = 0.5f;  // 120 BPM
 
     enum ParamId {
         MASTER_SPEED_PARAM,
@@ -167,6 +55,7 @@ struct Euclogic3 : Module {
         ENUMS(GATE_OUTPUT, NUM_CHANNELS),
         ENUMS(TRIG_OUTPUT, NUM_CHANNELS),
         ENUMS(LFO_OUTPUT, NUM_CHANNELS),
+        ENUMS(PRE_GATE_OUTPUT, NUM_CHANNELS),  // NEW: Pre-logic gate outputs
         OUTPUTS_LEN
     };
 
@@ -178,341 +67,29 @@ struct Euclogic3 : Module {
         LIGHTS_LEN
     };
 
-    // Core components
-    EuclideanEngine engines[NUM_CHANNELS];
-    ProbabilityGate probA[NUM_CHANNELS];
-    ProbabilityGate probB[NUM_CHANNELS];
-    TruthTable3 truthTable;
-
-    // Clock state
-    dsp::SchmittTrigger clockTrigger;
-    dsp::SchmittTrigger resetTrigger;
-    dsp::SchmittTrigger runTrigger;
-    dsp::SchmittTrigger randomTrigger;
-    dsp::SchmittTrigger mutateTrigger;
-    dsp::SchmittTrigger undoTrigger;
-    dsp::SchmittTrigger redoTrigger;
-
-    float clockPeriod = DEFAULT_CLOCK_PERIOD;
-    float timeSinceClock = 0.f;
-    float internalTickPhase = 0.f;
-    bool clockLocked = false;
-    bool running = true;
-    bool hadFirstTick = false;
-    int prevSpeedIdx = 8;
-    bool swingLong = true;
-
-    int quantCounter[NUM_CHANNELS] = {0};
-    dsp::PulseGenerator trigPulse[NUM_CHANNELS];
-    bool prevGateHigh[NUM_CHANNELS] = {false};
-    float retrigGapTimer[NUM_CHANNELS] = {0.f};
-
-    std::atomic<uint8_t> currentInputState{0};
-    std::atomic<bool> gateStates[NUM_CHANNELS];
+    EuclogicCore<3, true> core;
 
     Euclogic3() {
         config(PARAMS_LEN, INPUTS_LEN, OUTPUTS_LEN, LIGHTS_LEN);
-
-        configSwitch(MASTER_SPEED_PARAM, 0.f, SPEED_RATIOS_3.size() - 1, 8.f,
-            "Master Speed", SPEED_LABELS_3);
-        configParam(SWING_PARAM, 50.f, 75.f, 50.f, "Swing", "%");
-
-        configButton(RANDOM_PARAM, "Random");
-        configButton(MUTATE_PARAM, "Mutate");
-        configButton(UNDO_PARAM, "Undo");
-        configButton(REDO_PARAM, "Redo");
-
-        for (int i = 0; i < NUM_CHANNELS; i++) {
-            std::string ch = "Ch " + std::to_string(i + 1);
-
-            configParam(STEPS_PARAM + i, 1.f, 64.f, 16.f, ch + " Steps");
-            paramQuantities[STEPS_PARAM + i]->snapEnabled = true;
-
-            configParam(HITS_PARAM + i, 0.f, 64.f, 8.f, ch + " Hits");
-            paramQuantities[HITS_PARAM + i]->snapEnabled = true;
-            Hits3ParamQuantity* hitsQ = new Hits3ParamQuantity();
-            hitsQ->channel = i;
-            hitsQ->module = this;
-            hitsQ->paramId = HITS_PARAM + i;
-            hitsQ->minValue = 0.f;
-            hitsQ->maxValue = 64.f;
-            hitsQ->defaultValue = 8.f;
-            hitsQ->name = ch + " Hits";
-            hitsQ->snapEnabled = true;
-            delete paramQuantities[HITS_PARAM + i];
-            paramQuantities[HITS_PARAM + i] = hitsQ;
-
-            configSwitch(QUANT_PARAM + i, 0.f, QUANT_RATIOS_3.size() - 1, 0.f,
-                ch + " Quant", QUANT_LABELS_3);
-
-            configParam(PROB_A_PARAM + i, 0.f, 1.f, 1.f, ch + " Prob A", "%", 0.f, 100.f);
-            configParam(PROB_B_PARAM + i, 0.f, 1.f, 1.f, ch + " Prob B", "%", 0.f, 100.f);
-            configSwitch(RETRIG_PARAM + i, 0.f, 1.f, 1.f, ch + " Retrigger", {"Off", "On"});
-
-            configInput(HITS_CV_INPUT + i, ch + " Hits CV");
-            configInput(PROB_A_CV_INPUT + i, ch + " Prob A CV");
-            configInput(PROB_B_CV_INPUT + i, ch + " Prob B CV");
-
-            configOutput(GATE_OUTPUT + i, ch + " Gate");
-            configOutput(TRIG_OUTPUT + i, ch + " Trigger");
-            configOutput(LFO_OUTPUT + i, ch + " LFO");
-        }
-
-        configInput(CLOCK_INPUT, "Clock");
-        configInput(RESET_INPUT, "Reset");
-        configInput(RUN_INPUT, "Run");
-
-        configLight(CLOCK_LIGHT, "Clock Lock");
-        configLight(RUN_LIGHT, "Running");
-
-        // Initialize engines with default values
-        for (int i = 0; i < NUM_CHANNELS; i++) {
-            engines[i].configure(16, 8, 0);  // 16 steps, 8 hits
-            gateStates[i].store(false);
-        }
+        core.configureParams(this);
     }
 
     void onReset() override {
-        for (int i = 0; i < NUM_CHANNELS; i++) {
-            engines[i].reset();
-            quantCounter[i] = 0;
-            gateStates[i].store(false);
-            prevGateHigh[i] = false;
-            retrigGapTimer[i] = 0.f;
-        }
-        timeSinceClock = 0.f;
-        internalTickPhase = 0.f;
-        clockPeriod = DEFAULT_CLOCK_PERIOD;
-        running = true;
-        hadFirstTick = false;
-        prevSpeedIdx = 8;
-        swingLong = true;
-        currentInputState.store(0);
+        core.resetState();
     }
 
     void process(const ProcessArgs& args) override {
-        float dt = args.sampleTime;
-
-        if (resetTrigger.process(inputs[RESET_INPUT].getVoltage(), SCHMITT_LOW, SCHMITT_HIGH)) {
-            onReset();
-        }
-
-        if (inputs[RUN_INPUT].isConnected()) {
-            running = inputs[RUN_INPUT].getVoltage() > SCHMITT_HIGH;
-        } else {
-            running = true;
-        }
-        lights[RUN_LIGHT].setBrightness(running ? 1.f : 0.2f);
-
-        if (randomTrigger.process(params[RANDOM_PARAM].getValue())) {
-            truthTable.randomize();
-        }
-        if (mutateTrigger.process(params[MUTATE_PARAM].getValue())) {
-            truthTable.mutate();
-        }
-        if (undoTrigger.process(params[UNDO_PARAM].getValue())) {
-            truthTable.undo();
-        }
-        if (redoTrigger.process(params[REDO_PARAM].getValue())) {
-            truthTable.redo();
-        }
-
-        timeSinceClock += dt;
-
-        bool clockEdge = false;
-        if (clockTrigger.process(inputs[CLOCK_INPUT].getVoltage(), SCHMITT_LOW, SCHMITT_HIGH)) {
-            if (timeSinceClock > 0.001f) {
-                clockPeriod = timeSinceClock;
-                clockLocked = true;
-            }
-            timeSinceClock = 0.f;
-            clockEdge = true;
-        }
-
-        if (timeSinceClock > 2.f) {
-            clockLocked = false;
-            hadFirstTick = false;
-        }
-        lights[CLOCK_LIGHT].setBrightness(clockLocked ? 1.f : 0.2f);
-
-        int speedIdx = static_cast<int>(params[MASTER_SPEED_PARAM].getValue());
-        speedIdx = DSP::clamp(speedIdx, 0, (int)SPEED_RATIOS_3.size() - 1);
-        float masterSpeed = SPEED_RATIOS_3[speedIdx];
-
-        if (speedIdx != prevSpeedIdx) {
-            hadFirstTick = false;
-            internalTickPhase = 0.f;
-            prevSpeedIdx = speedIdx;
-        }
-
-        float swingPercent = params[SWING_PARAM].getValue();
-        float swingRatio = swingPercent / 100.f;
-
-        bool shouldTick = false;
-        if (running && clockLocked) {
-            float baseInterval = clockPeriod / masterSpeed;
-            float longInterval = 2.f * baseInterval * swingRatio;
-            float shortInterval = 2.f * baseInterval * (1.f - swingRatio);
-            float currentInterval = swingLong ? longInterval : shortInterval;
-
-            if (clockEdge) {
-                shouldTick = true;
-                hadFirstTick = true;
-                swingLong = true;
-                internalTickPhase = 0.f;
-            } else if (hadFirstTick) {
-                internalTickPhase += dt;
-                if (internalTickPhase >= currentInterval) {
-                    internalTickPhase -= currentInterval;
-                    shouldTick = true;
-                    swingLong = !swingLong;
-                }
-            }
-        }
-
-        if (shouldTick) {
-            bool preLogicStates[NUM_CHANNELS] = {false};
-
-            for (int i = 0; i < NUM_CHANNELS; i++) {
-                int quantIdx = static_cast<int>(params[QUANT_PARAM + i].getValue());
-                quantIdx = DSP::clamp(quantIdx, 0, (int)QUANT_RATIOS_3.size() - 1);
-                float quantRatio = QUANT_RATIOS_3[quantIdx];
-
-                int divAmount = static_cast<int>(1.f / quantRatio);
-                if (divAmount < 1) divAmount = 1;
-
-                quantCounter[i]++;
-                if (quantCounter[i] >= divAmount) {
-                    quantCounter[i] = 0;
-
-                    int steps = static_cast<int>(params[STEPS_PARAM + i].getValue());
-                    float hitsBase = params[HITS_PARAM + i].getValue();
-                    float hitsCV = inputs[HITS_CV_INPUT + i].getVoltage() / 5.f * 12.f;
-                    int hits = static_cast<int>(hitsBase + hitsCV);
-                    hits = DSP::clamp(hits, 0, steps);
-
-                    engines[i].configure(steps, hits, 0);
-                    bool euclideanHit = engines[i].tick();
-
-                    float probABase = params[PROB_A_PARAM + i].getValue();
-                    float probACV = inputs[PROB_A_CV_INPUT + i].getVoltage() / 10.f;
-                    float probAVal = DSP::clamp(probABase + probACV, 0.f, 1.f);
-
-                    preLogicStates[i] = euclideanHit && probA[i].process(true, probAVal);
-                } else {
-                    preLogicStates[i] = false;
-                }
-            }
-
-            uint8_t inputState = (preLogicStates[0] ? 1 : 0) | (preLogicStates[1] ? 2 : 0) | (preLogicStates[2] ? 4 : 0);
-            currentInputState.store(inputState);
-
-            bool postLogicStates[NUM_CHANNELS];
-            truthTable.evaluate(preLogicStates, postLogicStates);
-
-            for (int i = 0; i < NUM_CHANNELS; i++) {
-                float probBBase = params[PROB_B_PARAM + i].getValue();
-                float probBCV = inputs[PROB_B_CV_INPUT + i].getVoltage() / 10.f;
-                float probBVal = DSP::clamp(probBBase + probBCV, 0.f, 1.f);
-
-                bool finalOutput = postLogicStates[i] && probB[i].process(true, probBVal);
-                bool retrigger = params[RETRIG_PARAM + i].getValue() > 0.5f;
-
-                bool shouldTrigger = finalOutput && (!prevGateHigh[i] || retrigger);
-                if (shouldTrigger) {
-                    trigPulse[i].trigger(TRIGGER_PULSE_DURATION);
-                }
-
-                // Start retrigger gap if we have consecutive hits with retrigger on
-                if (finalOutput && prevGateHigh[i] && retrigger) {
-                    retrigGapTimer[i] = RETRIG_GAP_DURATION;
-                }
-
-                gateStates[i].store(finalOutput);
-                prevGateHigh[i] = finalOutput;
-            }
-        }
-
-        // Output voltages
-        for (int i = 0; i < NUM_CHANNELS; i++) {
-            bool gate = gateStates[i].load();
-
-            // Handle retrigger gap - force gate low briefly for envelope retrigger
-            if (retrigGapTimer[i] > 0.f) {
-                retrigGapTimer[i] -= dt;
-                outputs[GATE_OUTPUT + i].setVoltage(0.f);
-            } else {
-                outputs[GATE_OUTPUT + i].setVoltage(gate ? 10.f : 0.f);
-            }
-
-            outputs[TRIG_OUTPUT + i].setVoltage(trigPulse[i].process(dt) ? 10.f : 0.f);
-            lights[GATE_LIGHT + i].setBrightness(gate ? 1.f : 0.f);
-
-            // LFO output: unipolar ramp 0-10V tracking step position
-            int steps = engines[i].steps;
-            int currentStep = engines[i].currentStep;
-            float phase = (steps > 1) ? (float)currentStep / (float)(steps - 1) : 0.f;
-            outputs[LFO_OUTPUT + i].setVoltage(phase * 10.f);
-        }
-
-        // Update LED matrix lights (8 states x 3 outputs)
-        uint8_t currentState = currentInputState.load();
-        for (int state = 0; state < 8; state++) {
-            uint8_t outputMask = truthTable.getMapping(state);
-            bool isCurrentState = (state == currentState);
-            for (int bit = 0; bit < 3; bit++) {
-                bool isSet = (outputMask >> bit) & 1;
-                float brightness = isSet ? (isCurrentState ? 1.f : 0.5f) : (isCurrentState ? 0.2f : 0.05f);
-                lights[LED_MATRIX_LIGHT + state * 3 + bit].setBrightness(brightness);
-            }
-        }
+        core.process(this, args.sampleTime);
     }
 
     json_t* dataToJson() override {
-        json_t* rootJ = json_object();
-        json_object_set_new(rootJ, "clockPeriod", json_real(clockPeriod));
-
-        json_t* mappingJ = json_array();
-        auto mapping = truthTable.serialize();
-        for (int i = 0; i < 8; i++) {
-            json_array_append_new(mappingJ, json_integer(mapping[i]));
-        }
-        json_object_set_new(rootJ, "truthTable", mappingJ);
-
-        return rootJ;
+        return core.dataToJson();
     }
 
     void dataFromJson(json_t* rootJ) override {
-        json_t* periodJ = json_object_get(rootJ, "clockPeriod");
-        if (periodJ) {
-            clockPeriod = json_real_value(periodJ);
-        }
-
-        json_t* mappingJ = json_object_get(rootJ, "truthTable");
-        if (mappingJ && json_is_array(mappingJ)) {
-            std::array<uint8_t, 8> mapping;
-            for (int i = 0; i < 8 && i < (int)json_array_size(mappingJ); i++) {
-                mapping[i] = json_integer_value(json_array_get(mappingJ, i));
-            }
-            truthTable.deserialize(mapping);
-        }
+        core.dataFromJson(rootJ);
     }
 };
-
-// HitsParamQuantity implementation
-float Hits3ParamQuantity::getMaxValue() {
-    Euclogic3* euclogic = dynamic_cast<Euclogic3*>(module);
-    if (euclogic) {
-        int steps = static_cast<int>(euclogic->params[Euclogic3::STEPS_PARAM + channel].getValue());
-        return static_cast<float>(steps);
-    }
-    return 64.f;
-}
-
-void Hits3ParamQuantity::setValue(float value) {
-    value = math::clamp(value, getMinValue(), getMaxValue());
-    ParamQuantity::setValue(value);
-}
 
 // Euclidean Pattern Display - shows 3 channels
 struct Euclidean3Display : LightWidget {
@@ -541,7 +118,7 @@ struct Euclidean3Display : LightWidget {
         }
 
         for (int ch = 0; ch < 3; ch++) {
-            const auto& engine = module->engines[ch];
+            const auto& engine = module->core.engines[ch];
             float y = ch * rowHeight;
             int steps = engine.steps;
             int currentStep = engine.currentStep;
@@ -618,7 +195,7 @@ struct TruthTable3Display : LightWidget {
         nvgFillColor(args.vg, nvgRGBA(15, 15, 25, 160));
         nvgFill(args.vg);
 
-        uint8_t currentState = module ? module->currentInputState.load() : 0;
+        uint8_t currentState = module ? module->core.currentInputState.load() : 0;
 
         for (int state = 0; state < 8; state++) {
             float y = state * rowH;
@@ -631,7 +208,6 @@ struct TruthTable3Display : LightWidget {
                 nvgFill(args.vg);
             }
 
-            // Input columns (A B C)
             for (int bit = 0; bit < 3; bit++) {
                 bool bitValue = (state >> (2 - bit)) & 1;
                 float x = bit * singleInputW;
@@ -642,7 +218,6 @@ struct TruthTable3Display : LightWidget {
                 nvgText(args.vg, x + singleInputW / 2.f, y + rowH / 2.f, bitValue ? "T" : "F", nullptr);
             }
 
-            // Separator
             nvgBeginPath(args.vg);
             nvgMoveTo(args.vg, inputColW, y);
             nvgLineTo(args.vg, inputColW, y + rowH);
@@ -650,8 +225,7 @@ struct TruthTable3Display : LightWidget {
             nvgStrokeWidth(args.vg, 1.f);
             nvgStroke(args.vg);
 
-            // Output columns (1 2 3)
-            uint8_t outputMask = module ? module->truthTable.getMapping(state) : 0;
+            uint8_t outputMask = module ? module->core.truthTable.getMapping(state) : 0;
             for (int outBit = 0; outBit < 3; outBit++) {
                 bool isSet = (outputMask >> outBit) & 1;
                 float x = inputColW + outBit * singleOutputW;
@@ -713,56 +287,45 @@ struct TruthTable3Display : LightWidget {
         int outBit = static_cast<int>((e.pos.x - inputColW) / singleOutputW);
 
         if (row >= 0 && row < 8 && outBit >= 0 && outBit < 3) {
-            module->truthTable.pushUndo();
-            module->truthTable.toggleBit(row, outBit);
+            module->core.truthTable.pushUndo();
+            module->core.truthTable.toggleBit(row, outBit);
             e.consume(this);
         }
-    }
-};
-
-// Snap knob for discrete switch parameters
-struct RoundBlackSnapKnob3 : RoundBlackKnob {
-    RoundBlackSnapKnob3() {
-        snap = true;
     }
 };
 
 struct Euclogic3Widget : ModuleWidget {
     Euclogic3Widget(Euclogic3* module) {
         setModule(module);
-        box.size = Vec(28 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT);  // 28HP
+        box.size = Vec(28 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT);
         addChild(new WiggleRoom::ImagePanel(
             asset::plugin(pluginInstance, "res/Euclogic3.png"), box.size));
 
-        // Screws
         addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH, 0)));
         addChild(createWidget<ScrewSilver>(Vec(box.size.x - 2 * RACK_GRID_WIDTH, 0)));
         addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
         addChild(createWidget<ScrewSilver>(Vec(box.size.x - 2 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-        // Layout: 28HP = 142.24mm wide
         float panelWidth = 142.24f;
 
-        // Top: Euclidean display (y=16-40mm) - taller for 3 rows
         float yEucDisplay = 16.f;
         Euclidean3Display* eucDisplay = createWidget<Euclidean3Display>(mm2px(Vec(4.f, yEucDisplay)));
         eucDisplay->module = module;
         eucDisplay->box.size = mm2px(Vec(panelWidth - 8.f, 20.f));
         addChild(eucDisplay);
 
-        // Channel controls (3 rows)
         float yChannel1 = 40.f;
         float yChannel2 = 52.f;
         float yChannel3 = 64.f;
-        float col1 = 10.f;   // Steps
-        float col2 = 24.f;   // Hits
-        float col3 = 38.f;   // Hits CV
-        float col4 = 52.f;   // Quant
-        float col5 = 66.f;   // Prob A
-        float col6 = 80.f;   // Prob A CV
-        float col7 = 94.f;   // Prob B
-        float col8 = 108.f;  // Prob B CV
-        float col9 = 126.f;  // Retrig
+        float col1 = 10.f;
+        float col2 = 24.f;
+        float col3 = 38.f;
+        float col4 = 52.f;
+        float col5 = 66.f;
+        float col6 = 80.f;
+        float col7 = 94.f;
+        float col8 = 108.f;
+        float col9 = 126.f;
 
         for (int i = 0; i < Euclogic3::NUM_CHANNELS; i++) {
             float y;
@@ -781,7 +344,6 @@ struct Euclogic3Widget : ModuleWidget {
             addParam(createParamCentered<CKSS>(mm2px(Vec(col9, y)), module, Euclogic3::RETRIG_PARAM + i));
         }
 
-        // Master clock inputs row
         float yClockRow = 76.f;
         addInput(createInputCentered<PJ301MPort>(mm2px(Vec(col1, yClockRow)), module, Euclogic3::CLOCK_INPUT));
         addChild(createLightCentered<SmallLight<GreenLight>>(mm2px(Vec(col1 + 5.f, yClockRow - 4.f)), module, Euclogic3::CLOCK_LIGHT));
@@ -789,34 +351,34 @@ struct Euclogic3Widget : ModuleWidget {
         addInput(createInputCentered<PJ301MPort>(mm2px(Vec(col3, yClockRow)), module, Euclogic3::RUN_INPUT));
         addChild(createLightCentered<SmallLight<GreenLight>>(mm2px(Vec(col3 + 5.f, yClockRow - 4.f)), module, Euclogic3::RUN_LIGHT));
 
-        // Speed and Swing (same row as clock)
-        addParam(createParamCentered<RoundBlackSnapKnob3>(mm2px(Vec(col5, yClockRow)), module, Euclogic3::MASTER_SPEED_PARAM));
+        addParam(createParamCentered<EuclogicSnapKnob>(mm2px(Vec(col5, yClockRow)), module, Euclogic3::MASTER_SPEED_PARAM));
         addParam(createParamCentered<RoundSmallBlackKnob>(mm2px(Vec(col7, yClockRow)), module, Euclogic3::SWING_PARAM));
 
-        // Truth table display (y=76-96mm, positioned on right side)
         float yTable = 76.f;
         TruthTable3Display* truthTableDisp = createWidget<TruthTable3Display>(mm2px(Vec(panelWidth - 50.f, yTable)));
         truthTableDisp->module = module;
         truthTableDisp->box.size = mm2px(Vec(46.f, 32.f));
         addChild(truthTableDisp);
 
-        // Buttons row (below truth table/speed)
         float yButtons = 88.f;
         addParam(createParamCentered<VCVButton>(mm2px(Vec(col1, yButtons)), module, Euclogic3::RANDOM_PARAM));
         addParam(createParamCentered<VCVButton>(mm2px(Vec(col2, yButtons)), module, Euclogic3::MUTATE_PARAM));
         addParam(createParamCentered<VCVButton>(mm2px(Vec(col3, yButtons)), module, Euclogic3::UNDO_PARAM));
         addParam(createParamCentered<VCVButton>(mm2px(Vec(col4, yButtons)), module, Euclogic3::REDO_PARAM));
 
-        // Outputs row (bottom)
+        // Pre-Logic gate outputs (NEW for Euclogic3)
         float yOutputs = 110.f;
+        float yPreOutputs = yOutputs - 10.f;
         for (int i = 0; i < Euclogic3::NUM_CHANNELS; i++) {
             float xBase = 14.f + i * 38.f;
-            // Gate
+            addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(xBase + 24.f, yPreOutputs)), module, Euclogic3::PRE_GATE_OUTPUT + i));
+        }
+
+        for (int i = 0; i < Euclogic3::NUM_CHANNELS; i++) {
+            float xBase = 14.f + i * 38.f;
             addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(xBase, yOutputs)), module, Euclogic3::GATE_OUTPUT + i));
             addChild(createLightCentered<SmallLight<GreenLight>>(mm2px(Vec(xBase, yOutputs - 5)), module, Euclogic3::GATE_LIGHT + i));
-            // Trigger
             addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(xBase + 12.f, yOutputs)), module, Euclogic3::TRIG_OUTPUT + i));
-            // LFO
             addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(xBase + 24.f, yOutputs)), module, Euclogic3::LFO_OUTPUT + i));
         }
     }


### PR DESCRIPTION
## Summary
- Extracts shared logic from 3 Euclogic modules into `EuclogicCore<N, HAS_PRE_GATE>` template header — bugs now fixed once instead of three times
- Templates `TruthTable.hpp` into `TruthTableT<N>`, eliminating inline `TruthTable2` and `TruthTable3` duplicates
- Adds PRE_GATE outputs to Euclogic3 for consistency with Euclogic (4ch) and Euclogic2 (2ch)
- Includes the LFO range fix (`currentStep / (steps-1)`) from issue #21 in the shared core
- Net reduction: **-845 lines** (~700-800 lines per module → ~300 lines each)

## Test plan
- [x] `just build` — all three modules compile cleanly
- [x] `./build/test/euclogic_test --test-lfo-phase` — 9/9 passed (regression test for #21)
- [x] All euclogic unit tests pass (Euclidean patterns, truth table, probability, clock mult, timing)
- [x] `just install` — plugin installs to VCV Rack
- [ ] Load all three modules in VCV Rack, verify gates/triggers/LFO/truth table function
- [ ] Verify Euclogic3 now has PRE_GATE outputs
- [ ] Save/load patch to verify truth table serialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)