### PR TITLE
feat: OctoLFO per-channel Scale and Phase (NSEW)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -106,7 +106,7 @@
     {
       "slug": "OctoLFO",
       "name": "Octo LFO",
-      "description": "Clock-synced 8-channel LFO with wave shaping - Skew, Curve, and Fold modifiers with mini scope per channel",
+      "description": "Clock-synced 8-channel LFO with wave shaping - Skew, Curve, Fold, Scale, and Phase (NSEW) modifiers with mini scope per channel",
       "tags": ["Low-frequency oscillator", "Clock modulator", "Polyphonic"]
     },
     {


### PR DESCRIPTION
## Summary
- Adds per-channel **Scale** knob (0-100%) to attenuate LFO output amplitude
- Adds per-channel **Phase** switch with compass presets: N (0°), E (90°), S (180°), W (270°)
- Phase offset applied before waveform generation so scope shows actual output
- Widget layout updated with two new columns; Bipolar and Output shifted right

Closes #33

## Test plan
- [ ] `just build` compiles cleanly
- [ ] `just install` and open in VCV Rack
- [ ] Scale at 100% = identical to before, 0% = flat line, intermediate values attenuate
- [ ] Phase N = same as before, E = 90° ahead, S = inverted, W = 270° ahead
- [ ] Scope display reflects phase offset correctly
- [ ] All 8 channels work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>