### PR TITLE
docs: add user docs for all modules (synthesizes #45/#46/#47)

### DIFF
--- a/docs/user/modules/ACID9Seq.md
+++ b/docs/user/modules/ACID9Seq.md
@@ -1,0 +1,22 @@
+# ACID9Seq
+
+## Overview
+
+ACID9Seq is a WiggleRoom module in the **Sequencers & Clocks** category. A companion sequencer for ACID9Voice with a planetary display, two "gears" of pattern data, and a Scale Bus link for diatonic note generation.
+
+## Signal Flow
+
+- ACID9Seq is a sequencer — it does not process audio inline.
+- Inputs accept clock, reset, a 16-channel polyphonic Scale Bus, V/Oct transpose, freeze, and inject (randomize) triggers.
+- Outputs supply 1 V/Oct pitch and gate, intended to drive a synth voice (ACID9Voice or any V/Oct-compatible voice).
+
+## Typical Uses
+
+- Drive an ACID9Voice or other V/Oct voice from the Pitch and Gate outputs.
+- Send a Scale Bus from TheArchitect (or compatible) into the Scale Bus input to keep notes diatonic to the rest of the patch.
+- Use Freeze and Inject as performance gestures to fix or randomize Gear B mid-sequence.
+
+## Tips
+
+- Modulate V/Oct Transpose with a slow LFO or sequenced CV for evolving key/chord shifts that still respect the Scale Bus.
+- Use the planetary display as a visual cue for where in the cycle the sequencer is sitting.

--- a/docs/user/modules/ACID9Voice.md
+++ b/docs/user/modules/ACID9Voice.md
@@ -1,0 +1,23 @@
+# ACID9Voice
+
+## Overview
+
+ACID9Voice is a WiggleRoom module in the **Synthesizers & Oscillators** category. TB-303 inspired acid synth voice with morphing oscillator.
+
+## Signal Flow
+
+- Patch the primary input(s) into ACID9Voice and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate ACID9Voice into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/AnalogDrums.md
+++ b/docs/user/modules/AnalogDrums.md
@@ -1,0 +1,23 @@
+# AnalogDrums
+
+## Overview
+
+AnalogDrums is a WiggleRoom module in the **Synthesizers & Oscillators** category. Virtual analog drum machine with 12 independent voices.
+
+## Signal Flow
+
+- Patch the primary input(s) into AnalogDrums and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate AnalogDrums into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/ChaosPad.md
+++ b/docs/user/modules/ChaosPad.md
@@ -1,0 +1,23 @@
+# ChaosPad
+
+## Overview
+
+ChaosPad is a WiggleRoom module in the **Synthesizers & Oscillators** category. XY pad controller with 8 chaos-based effects.
+
+## Signal Flow
+
+- Patch the primary input(s) into ChaosPad and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate ChaosPad into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/EucBank.md
+++ b/docs/user/modules/EucBank.md
@@ -1,0 +1,22 @@
+# EucBank
+
+## Overview
+
+EucBank is a WiggleRoom module in the **Sequencers & Clocks** category. A 16-slot pattern storage and recall manager for the EucSeq + LogicMangler expander chain.
+
+## Signal Flow
+
+- EucBank is a pattern bank — it has no audio or CV outputs of its own; it stores and recalls patterns on neighbouring modules via the expander connection.
+- Inputs accept Step and Reset to advance and reset the active bank slot.
+- Bank changes are communicated to adjacent EucSeq / LogicMangler modules through the WiggleRoom expander side-bus.
+
+## Typical Uses
+
+- Step through 16 stored patterns over the course of a song using a slow clock divider.
+- Reset to slot 1 at song-section boundaries for predictable recall.
+- Build a song-mode controller by sequencing the Step input from another sequencer's CV/trigger output.
+
+## Tips
+
+- Place EucBank directly next to EucSeq (and LogicMangler if used) so the expander bus connects.
+- Drive Step with a clocked trigger source rather than continuous CV.

--- a/docs/user/modules/EucMix.md
+++ b/docs/user/modules/EucMix.md
@@ -1,0 +1,22 @@
+# EucMix
+
+## Overview
+
+EucMix is a WiggleRoom module in the **Sequencers & Clocks** category. A 4×4 CV summing matrix that works standalone or as a CV-mixing expander for the EucSeq chain.
+
+## Signal Flow
+
+- EucMix is a CV mixer — it is designed for control-rate CV, not audio-rate signals.
+- Inputs accept four CV sources.
+- Outputs supply four mixed CV signals, each a configurable sum of the inputs.
+
+## Typical Uses
+
+- Sum and route CV from up to four sources into four destinations with independent weightings.
+- Use as the CV-mix expander adjacent to EucSeq to combine its per-channel CV outputs.
+- Mix LFO, sequencer CV, and envelope sources to drive complex modulation on a single destination.
+
+## Tips
+
+- Keep individual contributions modest — summed CV can easily exceed ±10 V if all inputs are at full scale.
+- Use attenuators upstream when you want fine control over the contribution of a noisy CV source.

--- a/docs/user/modules/EucSeq.md
+++ b/docs/user/modules/EucSeq.md
@@ -1,0 +1,22 @@
+# EucSeq
+
+## Overview
+
+EucSeq is a WiggleRoom module in the **Sequencers & Clocks** category. A 4-channel Euclidean sequencer with per-channel hits/steps, per-step CV values, probability gates, and an expander connection out to LogicMangler.
+
+## Signal Flow
+
+- EucSeq is a sequencer — it does not process audio inline.
+- Inputs accept clock and per-channel CV for hits, steps, and probability.
+- Each of the four channels emits Gate, Trigger, LFO, and CV outputs, intended to drive voices, drum modules, or modulation destinations.
+
+## Typical Uses
+
+- Drive four drum voices from the Gate outputs for layered Euclidean rhythms.
+- Use the per-step CV output to send pitch or filter modulation in lockstep with the gate pattern.
+- Daisy-chain into LogicMangler (as an expander) to apply truth-table logic to the gate streams.
+
+## Tips
+
+- Slowly modulate Hits CV or Steps CV with an LFO for evolving Euclidean rotations.
+- Mute a channel's gate while leaving its CV output running to keep modulation without firing voices.

--- a/docs/user/modules/GravityClock.md
+++ b/docs/user/modules/GravityClock.md
@@ -1,0 +1,22 @@
+# GravityClock
+
+## Overview
+
+GravityClock is a WiggleRoom module in the **Sequencers & Clocks** category. Clock-synced bouncing-ball physics that emits an LFO tracking the ball's position and an impact trigger when it strikes the ground, locked to musical divisions.
+
+## Signal Flow
+
+- GravityClock is a modulation/trigger generator — it does not process audio inline.
+- Inputs accept a clock and a ratio CV.
+- Outputs are the ball-position LFO and an impact trigger.
+
+## Typical Uses
+
+- Patch the impact trigger into a drum voice or envelope generator for ratcheting, decaying hit patterns.
+- Use the position LFO to modulate filter cutoffs or pan for movement that decays with each bounce.
+- Combine with another clock divider to layer impacts against a straight grid.
+
+## Tips
+
+- Modulate the Ratio CV slowly with an LFO for ball physics that breathe over time.
+- Use attenuators on the LFO output to keep modulation depth musical.

--- a/docs/user/modules/InfiniteFolder.md
+++ b/docs/user/modules/InfiniteFolder.md
@@ -1,0 +1,23 @@
+# InfiniteFolder
+
+## Overview
+
+InfiniteFolder is a WiggleRoom module in the **Filters & Effects** category. West Coast-style wavefolder with infinite folding.
+
+## Signal Flow
+
+- Patch the primary input(s) into InfiniteFolder and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate InfiniteFolder into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/Linkage.md
+++ b/docs/user/modules/Linkage.md
@@ -1,0 +1,23 @@
+# Linkage
+
+## Overview
+
+Linkage is a WiggleRoom module in the **Physical Modeling Synthesis** category. Chaotic percussion generator using coupled physical spring model.
+
+## Signal Flow
+
+- Patch the primary input(s) into Linkage and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate Linkage into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/LogicMangler.md
+++ b/docs/user/modules/LogicMangler.md
@@ -1,0 +1,22 @@
+# LogicMangler
+
+## Overview
+
+LogicMangler is a WiggleRoom module in the **Sequencers & Clocks** category. A 4-input truth-table logic processor with cell locking, density control, and row/column randomize — usable standalone or as an EucSeq expander.
+
+## Signal Flow
+
+- LogicMangler is a gate/logic processor — it does not process audio inline.
+- Inputs accept four gate streams plus per-channel probability CV.
+- Outputs supply four processed gate streams and corresponding triggers.
+
+## Typical Uses
+
+- Take four EucSeq (or any) gate streams as inputs and re-derive new rhythmic gate patterns via the truth table.
+- Lock individual cells to preserve hits you like while randomizing the rest.
+- Use the trigger outputs to fire drum voices or envelopes from logically combined patterns.
+
+## Tips
+
+- Use density to dial overall sparsity once you have a truth table you like.
+- Row/column randomize is a quick way to find new combinations while keeping cell locks intact.

--- a/docs/user/modules/Matter.md
+++ b/docs/user/modules/Matter.md
@@ -1,0 +1,23 @@
+# Matter
+
+## Overview
+
+Matter is a WiggleRoom module in the **Physical Modeling Synthesis** category. Struck solid inside a resonant tube — morphs from strings to bells.
+
+## Signal Flow
+
+- Patch the primary input(s) into Matter and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate Matter into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/NutShaker.md
+++ b/docs/user/modules/NutShaker.md
@@ -1,0 +1,23 @@
+# NutShaker
+
+## Overview
+
+NutShaker is a WiggleRoom module in the **Physical Modeling Synthesis** category. Physical model of a shaker/maraca instrument.
+
+## Signal Flow
+
+- Patch the primary input(s) into NutShaker and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate NutShaker into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/OctoLFO.md
+++ b/docs/user/modules/OctoLFO.md
@@ -1,0 +1,22 @@
+# OctoLFO
+
+## Overview
+
+OctoLFO is a WiggleRoom module in the **Utilities** category. An 8-channel clock-synced LFO with per-channel waveshaping (Skew, Curve, Fold, Scale, Phase NSEW) and a mini scope per channel.
+
+## Signal Flow
+
+- OctoLFO is a modulation source — it does not process audio inline.
+- Inputs accept a clock and a reset.
+- Each of the eight channels emits an LFO output, intended to modulate parameters on other modules.
+
+## Typical Uses
+
+- Drive filter cutoffs, oscillator FM, panner positions, or any CV-controllable parameter across eight related destinations.
+- Use the NSEW phase offsets to create quadrature relationships between channels (good for stereo motion, vector morphing).
+- Save patch variations to compare wave-shape settings against a fixed clock division.
+
+## Tips
+
+- Use attenuators on the LFO outputs to keep modulation depth musical.
+- Set Phase NSEW on a pair of channels for quadrature stereo motion.

--- a/docs/user/modules/PhysicalChoir.md
+++ b/docs/user/modules/PhysicalChoir.md
@@ -1,0 +1,23 @@
+# PhysicalChoir
+
+## Overview
+
+PhysicalChoir is a WiggleRoom module in the **Physical Modeling Synthesis** category. Vocal choir synthesis with multiple voice types.
+
+## Signal Flow
+
+- Patch the primary input(s) into PhysicalChoir and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate PhysicalChoir into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/PreFlightClock.md
+++ b/docs/user/modules/PreFlightClock.md
@@ -1,0 +1,22 @@
+# PreFlightClock
+
+## Overview
+
+PreFlightClock is a WiggleRoom module in the **Sequencers & Clocks** category. Master clock with an Ableton-style count-in: fires a reset, plays four metronome beeps, then starts the run on the downbeat.
+
+## Signal Flow
+
+- PreFlightClock is a clock generator — it does not process audio inline.
+- Inputs accept BPM CV (0–10 V = 30–300 BPM), play trigger, and stop trigger.
+- Outputs provide a metronome click, reset pulse, run gate, and multiplied/divided clocks (x1/x2/x3/x4/x8/x16/x32 and /1.5 / /2 / /3 / /4 / /8 / /16 / /32).
+
+## Typical Uses
+
+- Use as the master clock for a sequenced patch; route the run gate to start/stop downstream sequencers cleanly on the downbeat.
+- Drive multiple time-base destinations from the divider outputs (e.g. x4 for hats, /4 for chord changes).
+- Send the metronome output to an audio mixer when recording so takes line up with the count-in.
+
+## Tips
+
+- The reset fires before the count-in begins, so sequencers reset to step 1 in time for the first beat.
+- Modulate BPM CV slowly with an LFO for tempo wobble; instantaneous jumps can produce uneven first ticks.

--- a/docs/user/modules/SpaceCello.md
+++ b/docs/user/modules/SpaceCello.md
@@ -1,0 +1,23 @@
+# SpaceCello
+
+## Overview
+
+SpaceCello is a WiggleRoom module in the **Physical Modeling Synthesis** category. Digital Yaybahar — bowed string with spring reverb coupling.
+
+## Signal Flow
+
+- Patch the primary input(s) into SpaceCello and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate SpaceCello into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/SpectraHenge.md
+++ b/docs/user/modules/SpectraHenge.md
@@ -1,0 +1,22 @@
+# SpectraHenge
+
+## Overview
+
+SpectraHenge is a WiggleRoom module in the **Filters & Effects** category. A four-node spectral processor with stereo audio inputs, per-node X/Y CV, two global LFO inputs, and a send/return loop for inserting external effects inside the processing chain.
+
+## Signal Flow
+
+- Patch mono or stereo audio into the four input pairs; SpectraHenge processes them through its spectral nodes and outputs the result.
+- Send a node's audio out through the **Send** jack to an external effect, then bring it back through **Return L/R** to fold the processed signal back into SpectraHenge's mix.
+- CV inputs modulate the X/Y position of each node independently; LFO A/B add global X and Y drift across all nodes.
+
+## Typical Uses
+
+- Use as a multi-input spectral mixer where each input occupies a movable region of the spectrum.
+- Insert a reverb, delay, or filter in the send/return loop to colour SpectraHenge's internal signal path.
+- Animate the node positions with LFOs or sequenced CV for evolving, location-based timbral shifts.
+
+## Tips
+
+- Keep node Q moderate when sending heavy material through the return loop to avoid resonant build-up.
+- Use the global LFO inputs for slow movement and per-node CV for fast, targeted shifts.

--- a/docs/user/modules/TetanusCoil.md
+++ b/docs/user/modules/TetanusCoil.md
@@ -1,0 +1,23 @@
+# TetanusCoil
+
+## Overview
+
+TetanusCoil is a WiggleRoom module in the **Synthesizers & Oscillators** category. Chaotic oscillator with coupled nonlinear systems.
+
+## Signal Flow
+
+- Patch the primary input(s) into TetanusCoil and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate TetanusCoil into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/TheAbyss.md
+++ b/docs/user/modules/TheAbyss.md
@@ -1,0 +1,23 @@
+# TheAbyss
+
+## Overview
+
+TheAbyss is a WiggleRoom module in the **Physical Modeling Synthesis** category. Waterphone-inspired metallic percussion instrument.
+
+## Signal Flow
+
+- Patch the primary input(s) into TheAbyss and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate TheAbyss into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/TheCauldron.md
+++ b/docs/user/modules/TheCauldron.md
@@ -1,0 +1,23 @@
+# TheCauldron
+
+## Overview
+
+TheCauldron is a WiggleRoom module in the **Filters & Effects** category. Fluid wave math processor with chaotic modulation.
+
+## Signal Flow
+
+- Patch the primary input(s) into TheCauldron and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate TheCauldron into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/VektorX.md
+++ b/docs/user/modules/VektorX.md
@@ -1,0 +1,23 @@
+# VektorX
+
+## Overview
+
+VektorX is a WiggleRoom module in the **Synthesizers & Oscillators** category. Vector synthesis module with complex modulation.
+
+## Signal Flow
+
+- Patch the primary input(s) into VektorX and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate VektorX into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/XFade.md
+++ b/docs/user/modules/XFade.md
@@ -1,0 +1,23 @@
+# XFade
+
+## Overview
+
+XFade is a WiggleRoom module in the **Utilities** category. CV crossfader/mixer with Ring Mod and Fold modes.
+
+## Signal Flow
+
+- Patch the primary input(s) into XFade and monitor the module outputs.
+- Use panel controls to shape timbre, timing, and modulation response.
+- Add CV modulation to animate parameters during performance.
+
+## Typical Uses
+
+- Integrate XFade into a larger voice or effect chain.
+- Automate key controls with sequencers, envelopes, or LFOs.
+- Combine with other WiggleRoom modules for complex patches.
+
+## Tips
+
+- Start with moderate parameter settings, then increase depth gradually.
+- Use attenuators for external CV to keep modulation musical.
+- Save patch variations to compare subtle control changes.

--- a/docs/user/modules/index.md
+++ b/docs/user/modules/index.md
@@ -2,26 +2,55 @@
 
 Detailed documentation for each WiggleRoom module.
 
-## Physical Modeling
+## Physical Modeling Synthesis
 
-- [ChaosFlute](ChaosFlute.md) - Chaotic non-linear flute
-- [ModalBell](ModalBell.md) - Struck metal bar with tunable modes
-- [PluckedString](PluckedString.md) - Karplus-Strong plucked string
+- [ChaosFlute](ChaosFlute.md) - Chaotic non-linear flute with feedback and breath noise
+- [Linkage](Linkage.md) - Chaotic percussion generator using coupled physical spring model
+- [Matter](Matter.md) - Struck solid inside a resonant tube — morphs from strings to bells
+- [ModalBell](ModalBell.md) - Physical model of a struck metal bar with tunable modes
+- [NutShaker](NutShaker.md) - Physical model of a shaker/maraca instrument
+- [PhysicalChoir](PhysicalChoir.md) - Vocal choir synthesis with multiple voice types
+- [PluckedString](PluckedString.md) - Karplus-Strong plucked string with damping and position
+- [SpaceCello](SpaceCello.md) - Digital Yaybahar — bowed string with spring reverb coupling
+- [TheAbyss](TheAbyss.md) - Waterphone-inspired metallic percussion instrument
 
 ## Filters & Effects
 
-- [BigReverb](BigReverb.md) - Zita Rev1 algorithmic reverb
-- [LadderLPF](LadderLPF.md) - Classic 4-pole ladder lowpass
-- [SaturationEcho](SaturationEcho.md) - Vintage tape delay
-- [SpectralResonator](SpectralResonator.md) - 6-band resonant filter bank
-- [TriPhaseEnsemble](TriPhaseEnsemble.md) - 3-voice BBD string ensemble
+- [BigReverb](BigReverb.md) - Zita Rev1 algorithmic reverb with pre-delay and EQ
+- [InfiniteFolder](InfiniteFolder.md) - West Coast-style wavefolder with infinite folding
+- [LadderLPF](LadderLPF.md) - Classic 4-pole ladder lowpass filter with resonance
+- [SaturationEcho](SaturationEcho.md) - Vintage tape delay with saturation and modulation
+- [SpectraHenge](SpectraHenge.md) - Four-node spectral processor with stereo audio inputs and send/return loop
+- [SpectralResonator](SpectralResonator.md) - 6-band resonant filter bank for spectral shaping
+- [TheCauldron](TheCauldron.md) - Fluid wave math processor with chaotic modulation
+- [TriPhaseEnsemble](TriPhaseEnsemble.md) - 3-voice BBD string ensemble effect
 
-## Modulators
+## Synthesizers & Oscillators
 
-- [Cycloid](Cycloid.md) - Polar Euclidean sequencer
-- [Intersect](Intersect.md) - Rhythmic trigger generator
-- [TheArchitect](TheArchitect.md) - Polyphonic quantizer
+- [ACID9Voice](ACID9Voice.md) - TB-303 inspired acid synth voice with morphing oscillator
+- [AnalogDrums](AnalogDrums.md) - Virtual analog drum machine with 12 independent voices
+- [ChaosPad](ChaosPad.md) - XY pad controller with 8 chaos-based effects
+- [TetanusCoil](TetanusCoil.md) - Chaotic oscillator with coupled nonlinear systems
+- [VektorX](VektorX.md) - Vector synthesis module with complex modulation
+
+## Sequencers & Clocks
+
+- [ACID9Seq](ACID9Seq.md) - Companion sequencer for ACID9Voice with planetary display
+- [Cycloid](Cycloid.md) - Polar Euclidean sequencer with rotating patterns
+- [EucBank](EucBank.md) - 16-slot pattern storage/recall for EucSeq + LogicMangler chain
+- [EucMix](EucMix.md) - 4x4 CV summing matrix for standalone or expander use
+- [EucSeq](EucSeq.md) - 4-channel Euclidean sequencer with per-step CV values
+- [GravityClock](GravityClock.md) - Clock-synced bouncing ball trigger generator
+- [Intersect](Intersect.md) - Rhythmic trigger generator with set operations
+- [LogicMangler](LogicMangler.md) - Truth table logic processor with cell locking and density control
+- [PreFlightClock](PreFlightClock.md) - Master clock with Ableton-style count-in sequence
+
+## Utilities
+
+- [OctoLFO](OctoLFO.md) - 8-channel clock-synced LFO with multiple shapes
+- [TheArchitect](TheArchitect.md) - Polyphonic quantizer and chord machine
+- [XFade](XFade.md) - CV crossfader/mixer with Ring Mod and Fold modes
 
 ---
 
-For full module list, see the [main README](../../../README.md#modules-29).
+For source, module list, and installation, see the [main README](../../../README.md#modules-32).


### PR DESCRIPTION
## Summary

Synthesizes the three Codex-generated documentation PRs (#45, #46, #47) into a single MR and addresses the inline Codex review feedback from #46.

**Base content:** PR #47's index format — it's the only one with full per-module descriptions in the index and the least likely to be wrong.

**Additions over #47:**
- New pages: `PreFlightClock.md`, `SpectraHenge.md` (both omitted from all three PRs even though they ship in `plugin.json` and `src/modules/`).
- Index now includes those two modules under Filters & Effects and Sequencers & Clocks respectively.

**Feedback addressed:** Codex left six P2 comments on #46 pointing out that the generic \`VCO → Module → VCA\` patch examples are wrong for CV/clock/sequencer modules. The same shape of bad advice was present (more weakly) in #47's per-module pages. Rewrote the following pages to describe each module's actual clock/CV/gate I/O rather than implying an inline audio chain:

- `ACID9Seq.md` — clock/reset/Scale Bus in; V/Oct + gate out
- `EucBank.md` — pattern bank, no outputs, expander-only
- `EucMix.md` — 4×4 CV summing matrix (CV, not audio)
- `EucSeq.md` — 4-channel Euclidean sequencer with gate/trig/LFO/CV outs
- `GravityClock.md` — clock + LFO/trigger generator
- `LogicMangler.md` — gate logic processor
- `OctoLFO.md` — 8-channel modulation source

## Closes

- Closes #45
- Closes #46
- Closes #47

## Test plan

- [x] All 34 modules in \`src/modules/\` have a corresponding \`docs/user/modules/*.md\` page (verified manually + via index)
- [ ] Render the docs site locally and click through the index links to confirm none 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)