### PR TITLE
feat: Add PixelProbe — image-to-CV color sampler (synthesizes #49/#50/#51)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,9 @@ endif()
 if(EucMix_Module IN_LIST ACTIVE_MODULES)
     target_compile_definitions(${PROJECT_NAME} PRIVATE HAS_EUCMIX=1)
 endif()
+if(PixelProbe_Module IN_LIST ACTIVE_MODULES)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE HAS_PIXELPROBE=1)
+endif()
 # Set output name without lib prefix
 set_target_properties(${PROJECT_NAME} PROPERTIES
     PREFIX ""

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of creative modules for [VCV Rack 2](https://vcvrack.com/), built w
 
 **[Documentation](docs/README.md)** | **[Developer Guide](docs/developer/getting-started.md)** | **[Release Strategy](docs/RELEASE_STRATEGY.md)**
 
-## Modules (32)
+## Modules (33)
 
 ### Physical Modeling Synthesis
 | Module | Description |
@@ -57,6 +57,7 @@ A collection of creative modules for [VCV Rack 2](https://vcvrack.com/), built w
 | **OctoLFO** | 8-channel clock-synced LFO with multiple shapes |
 | **TheArchitect** | Polyphonic quantizer and chord machine |
 | **XFade** | CV crossfader/mixer with Ring Mod and Fold modes |
+| **PixelProbe** | Image-to-CV color sampler — probe an image with X/Y CV, output Hue/Saturation/Intensity |
 
 ## Installation
 

--- a/plugin.json
+++ b/plugin.json
@@ -216,6 +216,12 @@
       "name": "EucMix",
       "description": "4x4 CV summing matrix - standalone or expander for EucSeq chain CV mixing",
       "tags": ["Mixer", "Utility"]
+    },
+    {
+      "slug": "PixelProbe",
+      "name": "Pixel Probe",
+      "description": "Image-to-CV color sampler - load an image, address a probe with X/Y CV, get Hue/Saturation/Intensity as CV with pan/zoom and polar/bipolar output",
+      "tags": ["Sample and hold", "Controller", "Visual", "Utility"]
     }
   ]
 }

--- a/res/PixelProbe.svg
+++ b/res/PixelProbe.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="121.92mm" height="128.5mm" viewBox="0 0 121.92 128.5">
-  <rect width="121.92" height="128.5" fill="#1a1a1a"/>
-  <rect x="3" y="3" width="115.92" height="122.5" fill="#242424" stroke="#4a4a4a" stroke-width="0.6"/>
-  <text x="60.96" y="10" fill="#f2f2f2" font-size="4.5" text-anchor="middle" font-family="sans-serif" letter-spacing="0.6">PIXEL PROBE</text>
-  <text x="60.96" y="124" fill="#888" font-size="3" text-anchor="middle" font-family="sans-serif" letter-spacing="0.8">WIGGLE ROOM</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="40.64mm" height="128.5mm" viewBox="0 0 40.64 128.5">
+  <rect width="40.64" height="128.5" fill="#1a1a1a"/>
+  <rect x="3" y="3" width="34.64" height="122.5" fill="#242424" stroke="#4a4a4a" stroke-width="0.6"/>
+  <text x="20.32" y="10" fill="#f2f2f2" font-size="4.5" text-anchor="middle" font-family="sans-serif" letter-spacing="0.6">PIXEL PROBE</text>
+  <text x="20.32" y="124" fill="#888" font-size="3" text-anchor="middle" font-family="sans-serif" letter-spacing="0.8">WIGGLE ROOM</text>
 </svg>

--- a/res/PixelProbe.svg
+++ b/res/PixelProbe.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="121.92mm" height="128.5mm" viewBox="0 0 121.92 128.5">
+  <rect width="121.92" height="128.5" fill="#1a1a1a"/>
+  <rect x="3" y="3" width="115.92" height="122.5" fill="#242424" stroke="#4a4a4a" stroke-width="0.6"/>
+  <text x="60.96" y="10" fill="#f2f2f2" font-size="4.5" text-anchor="middle" font-family="sans-serif" letter-spacing="0.6">PIXEL PROBE</text>
+  <text x="60.96" y="124" fill="#888" font-size="3" text-anchor="middle" font-family="sans-serif" letter-spacing="0.8">WIGGLE ROOM</text>
+</svg>

--- a/scripts/generate_faceplate.py
+++ b/scripts/generate_faceplate.py
@@ -71,6 +71,7 @@ MODULE_HP = {
     "EucBank": 8,
     "EucMix": 6,
     "Euclogic3": 28,
+    "PixelProbe": 8,
 }
 
 

--- a/src/modules/PixelProbe/CMakeLists.txt
+++ b/src/modules/PixelProbe/CMakeLists.txt
@@ -1,0 +1,8 @@
+# PixelProbe - image-to-CV color sampler (native C++, no Faust)
+
+add_library(PixelProbe_Module STATIC PixelProbe.cpp)
+target_link_libraries(PixelProbe_Module PRIVATE RackSDK)
+
+if(TARGET CommonLib)
+    target_link_libraries(PixelProbe_Module PRIVATE CommonLib)
+endif()

--- a/src/modules/PixelProbe/PixelProbe.cpp
+++ b/src/modules/PixelProbe/PixelProbe.cpp
@@ -67,10 +67,10 @@ struct PixelProbe : Module {
     // Last-sampled normalized canvas coordinate (within [0, 1]^2) after
     // pan/zoom. The widget reads these to draw the probe marker at the
     // actually-sampled location instead of the raw CV position.
-    // Updated only from the audio thread; widget reads it for display
-    // (single-writer / single-reader floats; tearing here is cosmetic).
-    float sampledU = 0.5f;
-    float sampledV = 0.5f;
+    // Written from the audio thread, read from the UI thread — atomic to
+    // avoid a data race (relaxed ordering: these are purely cosmetic).
+    std::atomic<float> sampledU{0.5f};
+    std::atomic<float> sampledV{0.5f};
 
     PixelProbe() {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
@@ -111,6 +111,13 @@ struct PixelProbe : Module {
         return true;
     }
 
+    // Reset to the empty-image state (no pixels, no path). Used when a load
+    // fails or when restoring a patch that had no image, so state restore is
+    // deterministic and the module stops emitting stale colors.
+    void clearMedia() {
+        publishImage(std::make_shared<const ImageData>());
+    }
+
     std::string loadedPath() const {
         return snapshotImage()->path;
     }
@@ -145,8 +152,8 @@ struct PixelProbe : Module {
         float v = (yCv / zoom + panY + 1.f) * 0.5f;
         u = clamp(u, 0.f, 1.f);
         v = clamp(v, 0.f, 1.f);
-        sampledU = u;
-        sampledV = v;
+        sampledU.store(u, std::memory_order_relaxed);
+        sampledV.store(v, std::memory_order_relaxed);
 
         if (!img || img->pixels.empty() || img->w <= 0 || img->h <= 0) {
             outputs[HUE_OUTPUT].setVoltage(0.f);
@@ -195,9 +202,15 @@ struct PixelProbe : Module {
 
     void dataFromJson(json_t* rootJ) override {
         json_t* pJ = json_object_get(rootJ, "loadedPath");
+        std::string p;
         if (pJ && json_is_string(pJ)) {
-            std::string p = json_string_value(pJ);
-            if (!p.empty()) loadMedia(p);
+            p = json_string_value(pJ);
+        }
+        // Deterministic restore: an empty path, a missing key, or a failed
+        // reload (file moved/deleted) all reset to the empty image so we
+        // never keep outputting colors from a previously-loaded picture.
+        if (p.empty() || !loadMedia(p)) {
+            clearMedia();
         }
     }
 };
@@ -215,39 +228,71 @@ struct PixelCanvas : Widget {
     int nvgHandle = -1;
     std::shared_ptr<const ImageData> uploaded;
 
-    // Last NanoVG context observed in draw(). Cached so the destructor can
-    // free the GPU image when the widget is torn down (Codex P2 #192).
-    NVGcontext* lastVg = nullptr;
+    // The NanoVG context the current handle was created against. VCV can
+    // destroy and recreate the GL/NanoVG context (e.g. a VST host closing and
+    // reopening its window); when that happens a new vg pointer appears and
+    // the old handle id is meaningless. We track the owning context so we
+    // never reuse a stale handle or delete it against the wrong context.
+    NVGcontext* handleVg = nullptr;
 
     ~PixelCanvas() override {
-        if (nvgHandle != -1 && lastVg) {
-            nvgDeleteImage(lastVg, nvgHandle);
-            nvgHandle = -1;
+        // On plain module removal the GL context is still alive, so free the
+        // GPU image to avoid a leak. If the context was already torn down,
+        // onContextDestroy() has already reset the handle.
+        if (nvgHandle != -1 && handleVg) {
+            nvgDeleteImage(handleVg, nvgHandle);
         }
+        nvgHandle = -1;
+        handleVg = nullptr;
+    }
+
+    // Drop the cached handle without touching a (possibly dead) context.
+    void invalidateHandle() {
+        nvgHandle = -1;
+        handleVg = nullptr;
+        uploaded.reset();
+    }
+
+    void onContextCreate(const ContextCreateEvent& e) override {
+        // A fresh context: any cached handle belonged to the old one.
+        invalidateHandle();
+        Widget::onContextCreate(e);
+    }
+
+    void onContextDestroy(const ContextDestroyEvent& e) override {
+        // Free the GPU image against the context that owns it, then forget it
+        // so the next draw() uploads fresh against the new context.
+        if (nvgHandle != -1 && handleVg == e.vg) {
+            nvgDeleteImage(e.vg, nvgHandle);
+        }
+        invalidateHandle();
+        Widget::onContextDestroy(e);
     }
 
     void ensureTexture(NVGcontext* vg,
                        const std::shared_ptr<const ImageData>& img) {
+        // Defensive: if the context changed without an explicit destroy/create
+        // notification, abandon the stale handle rather than delete it on the
+        // wrong context.
+        if (nvgHandle != -1 && handleVg != vg) {
+            invalidateHandle();
+        }
         bool empty = !img || img->pixels.empty() || img->w <= 0 || img->h <= 0;
         if (empty) {
-            if (nvgHandle != -1) {
-                nvgDeleteImage(vg, nvgHandle);
-                nvgHandle = -1;
-            }
-            uploaded.reset();
+            if (nvgHandle != -1) nvgDeleteImage(vg, nvgHandle);
+            invalidateHandle();
             return;
         }
         if (nvgHandle == -1 || img != uploaded) {
             if (nvgHandle != -1) nvgDeleteImage(vg, nvgHandle);
             nvgHandle = nvgCreateImageRGBA(vg, img->w, img->h, 0,
                                             img->pixels.data());
+            handleVg = vg;
             uploaded = img;
         }
     }
 
     void draw(const DrawArgs& args) override {
-        lastVg = args.vg;
-
         // Background
         nvgBeginPath(args.vg);
         nvgRect(args.vg, 0, 0, box.size.x, box.size.y);
@@ -277,14 +322,16 @@ struct PixelCanvas : Widget {
         }
 
         // Probe marker at the actually-sampled point.
+        float sampledU = module->sampledU.load(std::memory_order_relaxed);
+        float sampledV = module->sampledV.load(std::memory_order_relaxed);
         float sx, sy;
         if (nvgHandle != -1) {
-            sx = ox + module->sampledU * drawW;
-            sy = oy + (1.f - module->sampledV) * drawH;
+            sx = ox + sampledU * drawW;
+            sy = oy + (1.f - sampledV) * drawH;
         } else {
             // No image: fall back to canvas-relative position.
-            sx = module->sampledU * box.size.x;
-            sy = (1.f - module->sampledV) * box.size.y;
+            sx = sampledU * box.size.x;
+            sy = (1.f - sampledV) * box.size.y;
         }
         sx = clamp(sx, 0.f, box.size.x);
         sy = clamp(sy, 0.f, box.size.y);

--- a/src/modules/PixelProbe/PixelProbe.cpp
+++ b/src/modules/PixelProbe/PixelProbe.cpp
@@ -2,15 +2,17 @@
 // Saturation, Intensity as CV. Native C++, no Faust DSP.
 //
 // Synthesizes Codex PRs #49 / #50 / #51 and addresses the inline Codex
-// review feedback from #49: persist loaded-image state (P2), draw the
-// probe marker at the actually-sampled coordinate (P2), and keep the
-// jack layout inside the panel bounds at 8 HP (P1).
+// review feedback from #49 (persist loaded-image state, draw the probe
+// marker at the actually-sampled coordinate, keep jacks inside the
+// panel bounds) and #52 (audio/UI race on image swap; nvgImage leak).
 
 #include "rack.hpp"
 #include <osdialog.h>
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -22,6 +24,18 @@ using namespace rack;
 extern Plugin* pluginInstance;
 
 namespace WiggleRoom {
+
+// Immutable image snapshot. The audio thread holds a `shared_ptr<const
+// ImageData>` for the duration of a process() call so it never observes
+// a half-written buffer. New loads create a fresh ImageData and atomically
+// swap the module's shared_ptr — the audio thread either sees the old
+// snapshot or the new one, never a torn state.
+struct ImageData {
+    std::vector<unsigned char> pixels;  // RGBA8
+    int w = 0;
+    int h = 0;
+    std::string path;
+};
 
 struct PixelProbe : Module {
     enum ParamId {
@@ -44,16 +58,17 @@ struct PixelProbe : Module {
     };
     enum LightId { NUM_LIGHTS };
 
-    // Loaded RGBA8 image data.
-    std::vector<unsigned char> pixels;
-    int imgW = 0;
-    int imgH = 0;
-    std::string loadedPath;
-    bool textureDirty = true;  // widget re-uploads to GPU when set
+    // The current image. Accessed atomically (free-function shared_ptr
+    // atomics, C++17). All loads (audio thread / UI thread / widget) take
+    // a snapshot via atomic_load; loadMedia / clearMedia publish a new
+    // snapshot via atomic_store.
+    std::shared_ptr<const ImageData> currentImage = std::make_shared<ImageData>();
 
     // Last-sampled normalized canvas coordinate (within [0, 1]^2) after
     // pan/zoom. The widget reads these to draw the probe marker at the
     // actually-sampled location instead of the raw CV position.
+    // Updated only from the audio thread; widget reads it for display
+    // (single-writer / single-reader floats; tearing here is cosmetic).
     float sampledU = 0.5f;
     float sampledV = 0.5f;
 
@@ -71,17 +86,33 @@ struct PixelProbe : Module {
         configOutput(INT_OUTPUT, "Intensity");
     }
 
+    std::shared_ptr<const ImageData> snapshotImage() const {
+        return std::atomic_load(&currentImage);
+    }
+
+    void publishImage(std::shared_ptr<const ImageData> img) {
+        std::atomic_store(&currentImage, std::move(img));
+    }
+
     bool loadMedia(const std::string& path) {
-        int c = 0;
-        unsigned char* data = stbi_load(path.c_str(), &imgW, &imgH, &c, 4);
-        if (!data || imgW <= 0 || imgH <= 0) {
+        int w = 0, h = 0, c = 0;
+        unsigned char* data = stbi_load(path.c_str(), &w, &h, &c, 4);
+        if (!data || w <= 0 || h <= 0) {
+            if (data) stbi_image_free(data);
             return false;
         }
-        pixels.assign(data, data + (imgW * imgH * 4));
+        auto img = std::make_shared<ImageData>();
+        img->pixels.assign(data, data + (w * h * 4));
+        img->w = w;
+        img->h = h;
+        img->path = path;
         stbi_image_free(data);
-        loadedPath = path;
-        textureDirty = true;
+        publishImage(std::move(img));
         return true;
+    }
+
+    std::string loadedPath() const {
+        return snapshotImage()->path;
     }
 
     static void rgbToHsi(float r, float g, float b, float& h, float& s, float& i) {
@@ -98,6 +129,11 @@ struct PixelProbe : Module {
     }
 
     void process(const ProcessArgs& /*args*/) override {
+        // Pin the current image for the duration of this block — the UI
+        // thread can swap currentImage in mid-flight without invalidating
+        // the buffers we're reading.
+        std::shared_ptr<const ImageData> img = snapshotImage();
+
         float xCv = clamp(inputs[X_INPUT].getVoltage() / 5.f, -1.f, 1.f);
         float yCv = clamp(inputs[Y_INPUT].getVoltage() / 5.f, -1.f, 1.f);
         float panX = params[PAN_X_PARAM].getValue();
@@ -112,22 +148,22 @@ struct PixelProbe : Module {
         sampledU = u;
         sampledV = v;
 
-        if (pixels.empty() || imgW <= 0 || imgH <= 0) {
+        if (!img || img->pixels.empty() || img->w <= 0 || img->h <= 0) {
             outputs[HUE_OUTPUT].setVoltage(0.f);
             outputs[SAT_OUTPUT].setVoltage(0.f);
             outputs[INT_OUTPUT].setVoltage(0.f);
             return;
         }
 
-        int px = clamp((int)std::round(u * (imgW - 1)), 0, imgW - 1);
+        int px = clamp((int)std::round(u * (img->w - 1)), 0, img->w - 1);
         // Image row 0 is at the top of the canvas; v = 0 sits at the bottom,
         // so we flip vertically when indexing the pixel buffer.
-        int py = clamp((int)std::round((1.f - v) * (imgH - 1)), 0, imgH - 1);
-        int idx = (py * imgW + px) * 4;
+        int py = clamp((int)std::round((1.f - v) * (img->h - 1)), 0, img->h - 1);
+        int idx = (py * img->w + px) * 4;
 
-        float r = pixels[idx]     / 255.f;
-        float g = pixels[idx + 1] / 255.f;
-        float b = pixels[idx + 2] / 255.f;
+        float r = img->pixels[idx]     / 255.f;
+        float g = img->pixels[idx + 1] / 255.f;
+        float b = img->pixels[idx + 2] / 255.f;
 
         float h, s, intensity;
         rgbToHsi(r, g, b, h, s, intensity);
@@ -150,9 +186,9 @@ struct PixelProbe : Module {
 
     json_t* dataToJson() override {
         json_t* rootJ = json_object();
-        if (!loadedPath.empty()) {
-            json_object_set_new(rootJ, "loadedPath",
-                                json_string(loadedPath.c_str()));
+        std::string p = loadedPath();
+        if (!p.empty()) {
+            json_object_set_new(rootJ, "loadedPath", json_string(p.c_str()));
         }
         return rootJ;
     }
@@ -172,31 +208,46 @@ struct PixelProbe : Module {
 
 struct PixelCanvas : Widget {
     PixelProbe* module = nullptr;
-    int nvgHandle = -1;
-    int uploadedW = 0;
-    int uploadedH = 0;
 
-    void ensureTexture(NVGcontext* vg) {
-        if (!module) return;
-        if (module->pixels.empty()) {
+    // GPU-side cache of the most recently uploaded image. Identified by
+    // shared_ptr identity rather than by image dimensions, so we re-upload
+    // whenever the module publishes a new ImageData snapshot.
+    int nvgHandle = -1;
+    std::shared_ptr<const ImageData> uploaded;
+
+    // Last NanoVG context observed in draw(). Cached so the destructor can
+    // free the GPU image when the widget is torn down (Codex P2 #192).
+    NVGcontext* lastVg = nullptr;
+
+    ~PixelCanvas() override {
+        if (nvgHandle != -1 && lastVg) {
+            nvgDeleteImage(lastVg, nvgHandle);
+            nvgHandle = -1;
+        }
+    }
+
+    void ensureTexture(NVGcontext* vg,
+                       const std::shared_ptr<const ImageData>& img) {
+        bool empty = !img || img->pixels.empty() || img->w <= 0 || img->h <= 0;
+        if (empty) {
             if (nvgHandle != -1) {
                 nvgDeleteImage(vg, nvgHandle);
                 nvgHandle = -1;
             }
+            uploaded.reset();
             return;
         }
-        if (nvgHandle == -1 || module->textureDirty ||
-            module->imgW != uploadedW || module->imgH != uploadedH) {
+        if (nvgHandle == -1 || img != uploaded) {
             if (nvgHandle != -1) nvgDeleteImage(vg, nvgHandle);
-            nvgHandle = nvgCreateImageRGBA(vg, module->imgW, module->imgH, 0,
-                                            module->pixels.data());
-            uploadedW = module->imgW;
-            uploadedH = module->imgH;
-            module->textureDirty = false;
+            nvgHandle = nvgCreateImageRGBA(vg, img->w, img->h, 0,
+                                            img->pixels.data());
+            uploaded = img;
         }
     }
 
     void draw(const DrawArgs& args) override {
+        lastVg = args.vg;
+
         // Background
         nvgBeginPath(args.vg);
         nvgRect(args.vg, 0, 0, box.size.x, box.size.y);
@@ -205,7 +256,8 @@ struct PixelCanvas : Widget {
 
         if (!module) return;
 
-        ensureTexture(args.vg);
+        std::shared_ptr<const ImageData> img = module->snapshotImage();
+        ensureTexture(args.vg, img);
 
         float zoom = std::max(0.01f, module->params[PixelProbe::ZOOM_PARAM].getValue());
         float panX = module->params[PixelProbe::PAN_X_PARAM].getValue();
@@ -224,7 +276,7 @@ struct PixelCanvas : Widget {
             nvgFill(args.vg);
         }
 
-        // Probe marker at the actually-sampled point (Codex P2 #124).
+        // Probe marker at the actually-sampled point.
         float sx, sy;
         if (nvgHandle != -1) {
             sx = ox + module->sampledU * drawW;
@@ -277,7 +329,7 @@ struct PixelProbeWidget : ModuleWidget {
 
         // 8 HP panel: box.size.x = 120 px, box.size.y = 380 px.
         // Square canvas at the top, controls + jacks below — all kept inside
-        // the 380 px panel height (Codex P1 #150).
+        // the 380 px panel height.
         const float margin = 8.f;
         auto* canvas = new PixelCanvas();
         canvas->box.pos = Vec(margin, 22.f);
@@ -323,9 +375,11 @@ struct PixelProbeWidget : ModuleWidget {
         auto* item = createMenuItem<LoadMediaItem>("Load image…");
         item->module = m;
         menu->addChild(item);
-        if (m && !m->loadedPath.empty()) {
-            menu->addChild(createMenuLabel(
-                std::string("Loaded: ") + m->loadedPath));
+        if (m) {
+            std::string p = m->loadedPath();
+            if (!p.empty()) {
+                menu->addChild(createMenuLabel(std::string("Loaded: ") + p));
+            }
         }
     }
 };

--- a/src/modules/PixelProbe/PixelProbe.cpp
+++ b/src/modules/PixelProbe/PixelProbe.cpp
@@ -1,0 +1,336 @@
+// PixelProbe — sample a CV-addressed point in an image and emit Hue,
+// Saturation, Intensity as CV. Native C++, no Faust DSP.
+//
+// Synthesizes Codex PRs #49 / #50 / #51 and addresses the inline Codex
+// review feedback from #49: persist loaded-image state (P2), draw the
+// probe marker at the actually-sampled coordinate (P2), and keep the
+// jack layout inside the panel bounds at 8 HP (P1).
+
+#include "rack.hpp"
+#include <osdialog.h>
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_STATIC
+#include "stb_image.h"
+
+using namespace rack;
+extern Plugin* pluginInstance;
+
+namespace WiggleRoom {
+
+struct PixelProbe : Module {
+    enum ParamId {
+        PAN_X_PARAM,
+        PAN_Y_PARAM,
+        ZOOM_PARAM,
+        MODE_PARAM,
+        NUM_PARAMS
+    };
+    enum InputId {
+        X_INPUT,
+        Y_INPUT,
+        NUM_INPUTS
+    };
+    enum OutputId {
+        HUE_OUTPUT,
+        SAT_OUTPUT,
+        INT_OUTPUT,
+        NUM_OUTPUTS
+    };
+    enum LightId { NUM_LIGHTS };
+
+    // Loaded RGBA8 image data.
+    std::vector<unsigned char> pixels;
+    int imgW = 0;
+    int imgH = 0;
+    std::string loadedPath;
+    bool textureDirty = true;  // widget re-uploads to GPU when set
+
+    // Last-sampled normalized canvas coordinate (within [0, 1]^2) after
+    // pan/zoom. The widget reads these to draw the probe marker at the
+    // actually-sampled location instead of the raw CV position.
+    float sampledU = 0.5f;
+    float sampledV = 0.5f;
+
+    PixelProbe() {
+        config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
+        configParam(PAN_X_PARAM, -1.f, 1.f, 0.f, "Pan X");
+        configParam(PAN_Y_PARAM, -1.f, 1.f, 0.f, "Pan Y");
+        configParam(ZOOM_PARAM, 0.2f, 4.f, 1.f, "Zoom");
+        configSwitch(MODE_PARAM, 0.f, 1.f, 0.f, "Output range",
+                     {"Polar (0..10 V)", "Bipolar (-5..+5 V)"});
+        configInput(X_INPUT, "X probe (-5..+5 V)");
+        configInput(Y_INPUT, "Y probe (-5..+5 V)");
+        configOutput(HUE_OUTPUT, "Hue");
+        configOutput(SAT_OUTPUT, "Saturation");
+        configOutput(INT_OUTPUT, "Intensity");
+    }
+
+    bool loadMedia(const std::string& path) {
+        int c = 0;
+        unsigned char* data = stbi_load(path.c_str(), &imgW, &imgH, &c, 4);
+        if (!data || imgW <= 0 || imgH <= 0) {
+            return false;
+        }
+        pixels.assign(data, data + (imgW * imgH * 4));
+        stbi_image_free(data);
+        loadedPath = path;
+        textureDirty = true;
+        return true;
+    }
+
+    static void rgbToHsi(float r, float g, float b, float& h, float& s, float& i) {
+        float sum = r + g + b;
+        i = sum / 3.f;
+        float minc = std::min(r, std::min(g, b));
+        s = (sum > 1e-6f) ? (1.f - (3.f * minc / sum)) : 0.f;
+
+        float num = 0.5f * ((r - g) + (r - b));
+        float den = std::sqrt((r - g) * (r - g) + (r - b) * (g - b));
+        float theta = (den > 1e-6f) ? std::acos(clamp(num / den, -1.f, 1.f)) : 0.f;
+        if (b > g) theta = 2.f * (float)M_PI - theta;
+        h = theta / (2.f * (float)M_PI);
+    }
+
+    void process(const ProcessArgs& /*args*/) override {
+        float xCv = clamp(inputs[X_INPUT].getVoltage() / 5.f, -1.f, 1.f);
+        float yCv = clamp(inputs[Y_INPUT].getVoltage() / 5.f, -1.f, 1.f);
+        float panX = params[PAN_X_PARAM].getValue();
+        float panY = params[PAN_Y_PARAM].getValue();
+        float zoom = std::max(0.01f, params[ZOOM_PARAM].getValue());
+
+        // CV (-1..+1) -> normalized image coord (0..1), with pan/zoom.
+        float u = (xCv / zoom + panX + 1.f) * 0.5f;
+        float v = (yCv / zoom + panY + 1.f) * 0.5f;
+        u = clamp(u, 0.f, 1.f);
+        v = clamp(v, 0.f, 1.f);
+        sampledU = u;
+        sampledV = v;
+
+        if (pixels.empty() || imgW <= 0 || imgH <= 0) {
+            outputs[HUE_OUTPUT].setVoltage(0.f);
+            outputs[SAT_OUTPUT].setVoltage(0.f);
+            outputs[INT_OUTPUT].setVoltage(0.f);
+            return;
+        }
+
+        int px = clamp((int)std::round(u * (imgW - 1)), 0, imgW - 1);
+        // Image row 0 is at the top of the canvas; v = 0 sits at the bottom,
+        // so we flip vertically when indexing the pixel buffer.
+        int py = clamp((int)std::round((1.f - v) * (imgH - 1)), 0, imgH - 1);
+        int idx = (py * imgW + px) * 4;
+
+        float r = pixels[idx]     / 255.f;
+        float g = pixels[idx + 1] / 255.f;
+        float b = pixels[idx + 2] / 255.f;
+
+        float h, s, intensity;
+        rgbToHsi(r, g, b, h, s, intensity);
+
+        bool bipolar = params[MODE_PARAM].getValue() > 0.5f;
+        auto mapOut = [&](float val) {
+            return bipolar ? (val * 10.f - 5.f) : (val * 10.f);
+        };
+
+        outputs[HUE_OUTPUT].setVoltage(mapOut(h));
+        outputs[SAT_OUTPUT].setVoltage(mapOut(s));
+        outputs[INT_OUTPUT].setVoltage(mapOut(intensity));
+    }
+
+    // ---- Persistence ------------------------------------------------------
+    // Persist the loaded image path so patches survive save/load. On load
+    // we attempt to re-read the file; if it has moved or been deleted, the
+    // module behaves as if no image is loaded and the user can re-pick via
+    // the context menu.
+
+    json_t* dataToJson() override {
+        json_t* rootJ = json_object();
+        if (!loadedPath.empty()) {
+            json_object_set_new(rootJ, "loadedPath",
+                                json_string(loadedPath.c_str()));
+        }
+        return rootJ;
+    }
+
+    void dataFromJson(json_t* rootJ) override {
+        json_t* pJ = json_object_get(rootJ, "loadedPath");
+        if (pJ && json_is_string(pJ)) {
+            std::string p = json_string_value(pJ);
+            if (!p.empty()) loadMedia(p);
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Widget
+// ---------------------------------------------------------------------------
+
+struct PixelCanvas : Widget {
+    PixelProbe* module = nullptr;
+    int nvgHandle = -1;
+    int uploadedW = 0;
+    int uploadedH = 0;
+
+    void ensureTexture(NVGcontext* vg) {
+        if (!module) return;
+        if (module->pixels.empty()) {
+            if (nvgHandle != -1) {
+                nvgDeleteImage(vg, nvgHandle);
+                nvgHandle = -1;
+            }
+            return;
+        }
+        if (nvgHandle == -1 || module->textureDirty ||
+            module->imgW != uploadedW || module->imgH != uploadedH) {
+            if (nvgHandle != -1) nvgDeleteImage(vg, nvgHandle);
+            nvgHandle = nvgCreateImageRGBA(vg, module->imgW, module->imgH, 0,
+                                            module->pixels.data());
+            uploadedW = module->imgW;
+            uploadedH = module->imgH;
+            module->textureDirty = false;
+        }
+    }
+
+    void draw(const DrawArgs& args) override {
+        // Background
+        nvgBeginPath(args.vg);
+        nvgRect(args.vg, 0, 0, box.size.x, box.size.y);
+        nvgFillColor(args.vg, nvgRGB(20, 20, 20));
+        nvgFill(args.vg);
+
+        if (!module) return;
+
+        ensureTexture(args.vg);
+
+        float zoom = std::max(0.01f, module->params[PixelProbe::ZOOM_PARAM].getValue());
+        float panX = module->params[PixelProbe::PAN_X_PARAM].getValue();
+        float panY = module->params[PixelProbe::PAN_Y_PARAM].getValue();
+        float drawW = box.size.x * zoom;
+        float drawH = box.size.y * zoom;
+        float ox = (box.size.x - drawW) * 0.5f - panX * box.size.x * 0.5f;
+        float oy = (box.size.y - drawH) * 0.5f - panY * box.size.y * 0.5f;
+
+        if (nvgHandle != -1) {
+            NVGpaint paint = nvgImagePattern(args.vg, ox, oy, drawW, drawH,
+                                              0.f, nvgHandle, 1.f);
+            nvgBeginPath(args.vg);
+            nvgRect(args.vg, 0, 0, box.size.x, box.size.y);
+            nvgFillPaint(args.vg, paint);
+            nvgFill(args.vg);
+        }
+
+        // Probe marker at the actually-sampled point (Codex P2 #124).
+        float sx, sy;
+        if (nvgHandle != -1) {
+            sx = ox + module->sampledU * drawW;
+            sy = oy + (1.f - module->sampledV) * drawH;
+        } else {
+            // No image: fall back to canvas-relative position.
+            sx = module->sampledU * box.size.x;
+            sy = (1.f - module->sampledV) * box.size.y;
+        }
+        sx = clamp(sx, 0.f, box.size.x);
+        sy = clamp(sy, 0.f, box.size.y);
+
+        nvgBeginPath(args.vg);
+        nvgCircle(args.vg, sx, sy, 4.f);
+        nvgStrokeColor(args.vg, nvgRGB(255, 255, 255));
+        nvgStrokeWidth(args.vg, 1.5f);
+        nvgStroke(args.vg);
+        nvgBeginPath(args.vg);
+        nvgCircle(args.vg, sx, sy, 1.6f);
+        nvgFillColor(args.vg, nvgRGB(255, 70, 70));
+        nvgFill(args.vg);
+    }
+};
+
+struct LoadMediaItem : MenuItem {
+    PixelProbe* module = nullptr;
+    void onAction(const event::Action& /*e*/) override {
+        if (!module) return;
+        char* path = osdialog_file(OSDIALOG_OPEN, nullptr, nullptr, nullptr);
+        if (path) {
+            module->loadMedia(path);
+            std::free(path);
+        }
+    }
+};
+
+struct PixelProbeWidget : ModuleWidget {
+    PixelProbeWidget(PixelProbe* module) {
+        setModule(module);
+        setPanel(createPanel(asset::plugin(pluginInstance, "res/PixelProbe.svg")));
+
+        addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH, 0)));
+        addChild(createWidget<ScrewSilver>(
+            Vec(box.size.x - 2 * RACK_GRID_WIDTH, 0)));
+        addChild(createWidget<ScrewSilver>(
+            Vec(RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
+        addChild(createWidget<ScrewSilver>(
+            Vec(box.size.x - 2 * RACK_GRID_WIDTH,
+                RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
+
+        // 8 HP panel: box.size.x = 120 px, box.size.y = 380 px.
+        // Square canvas at the top, controls + jacks below — all kept inside
+        // the 380 px panel height (Codex P1 #150).
+        const float margin = 8.f;
+        auto* canvas = new PixelCanvas();
+        canvas->box.pos = Vec(margin, 22.f);
+        canvas->box.size = Vec(box.size.x - 2 * margin,
+                                box.size.x - 2 * margin);
+        canvas->module = module;
+        addChild(canvas);
+
+        const float colL = box.size.x * 0.25f;
+        const float colC = box.size.x * 0.50f;
+        const float colR = box.size.x * 0.75f;
+
+        const float yKnobs = canvas->box.pos.y + canvas->box.size.y + 18.f;
+        addParam(createParamCentered<RoundSmallBlackKnob>(
+            Vec(colL, yKnobs), module, PixelProbe::PAN_X_PARAM));
+        addParam(createParamCentered<RoundSmallBlackKnob>(
+            Vec(colC, yKnobs), module, PixelProbe::PAN_Y_PARAM));
+        addParam(createParamCentered<RoundSmallBlackKnob>(
+            Vec(colR, yKnobs), module, PixelProbe::ZOOM_PARAM));
+
+        const float ySwitch = yKnobs + 28.f;
+        addParam(createParamCentered<CKSS>(
+            Vec(colC, ySwitch), module, PixelProbe::MODE_PARAM));
+
+        const float yInputs  = ySwitch + 32.f;
+        addInput(createInputCentered<PJ301MPort>(
+            Vec(colL, yInputs), module, PixelProbe::X_INPUT));
+        addInput(createInputCentered<PJ301MPort>(
+            Vec(colR, yInputs), module, PixelProbe::Y_INPUT));
+
+        const float yOutputs = yInputs + 32.f;
+        addOutput(createOutputCentered<PJ301MPort>(
+            Vec(colL, yOutputs), module, PixelProbe::HUE_OUTPUT));
+        addOutput(createOutputCentered<PJ301MPort>(
+            Vec(colC, yOutputs), module, PixelProbe::SAT_OUTPUT));
+        addOutput(createOutputCentered<PJ301MPort>(
+            Vec(colR, yOutputs), module, PixelProbe::INT_OUTPUT));
+    }
+
+    void appendContextMenu(Menu* menu) override {
+        auto* m = dynamic_cast<PixelProbe*>(this->module);
+        menu->addChild(new MenuSeparator());
+        auto* item = createMenuItem<LoadMediaItem>("Load image…");
+        item->module = m;
+        menu->addChild(item);
+        if (m && !m->loadedPath.empty()) {
+            menu->addChild(createMenuLabel(
+                std::string("Loaded: ") + m->loadedPath));
+        }
+    }
+};
+
+} // namespace WiggleRoom
+
+Model* modelPixelProbe = createModel<WiggleRoom::PixelProbe,
+                                      WiggleRoom::PixelProbeWidget>("PixelProbe");

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -108,6 +108,9 @@ extern Model* modelSpectraHenge;
 #ifdef HAS_PREFLIGHTCLOCK
 extern Model* modelPreFlightClock;
 #endif
+#ifdef HAS_PIXELPROBE
+extern Model* modelPixelProbe;
+#endif
 
 void init(Plugin* p) {
     pluginInstance = p;
@@ -213,5 +216,8 @@ void init(Plugin* p) {
 #endif
 #ifdef HAS_PREFLIGHTCLOCK
     p->addModel(modelPreFlightClock);
+#endif
+#ifdef HAS_PIXELPROBE
+    p->addModel(modelPixelProbe);
 #endif
 }


### PR DESCRIPTION
## Summary

Adds **PixelProbe**, an 8 HP native-C++ module that loads an image and reads back its color at a CV-addressable X/Y point as Hue/Saturation/Intensity CV. Synthesizes the three Codex-generated PRs (#49, #50, #51) into one.

- Load image via context menu (file picker, `stb_image` decoding — keeps stb symbols file-local via `STB_IMAGE_STATIC`).
- X/Y CV inputs (-5..+5 V) address the probe; Pan X / Pan Y / Zoom move and scale the image within the canvas.
- Mode switch: Polar (0..10 V) or Bipolar (-5..+5 V) outputs for Hue, Saturation, Intensity.
- Probe marker on the canvas tracks the actually-sampled image coordinate.

## Synthesis rationale

| PR | What it had | Why not as-is |
|----|-------------|---------------|
| #49 | Procedural placeholder image + SVG + Codex review feedback | No real image loading; jack layout coupled to `box.size.x`; `videoMode` never serialized |
| #50 | Same procedural approach as #49 | Missing `plugin.json` entry; no panel SVG |
| #51 | **Real image loading via `stb_image` + `osdialog_file` picker** | No SVG; probe marker drawn at canvas center, not sampled point; loaded path not persisted; recreated nvgImage every frame |

Took #51's image-loading core as the baseline and applied Codex's review feedback from #49.

## Codex feedback addressed

From inline reviews on #49:

- **P2 — Persist media state**: `dataToJson` / `dataFromJson` persist `loadedPath`; the image is re-read from disk on patch reload. Missing files leave an empty canvas.
- **P2 — Draw probe marker at sampled coordinate**: The widget now reads `sampledU/sampledV` (computed in `process()` after the pan/zoom transform) and draws the marker at the matching on-canvas pixel.
- **P1 — Keep jack layout inside panel bounds**: Layout is anchored to the canvas bottom (`canvas->box.pos.y + canvas->box.size.y + …`), not `box.size.x`. All controls and jacks fit inside an 8 HP / 380 px panel.

## Closes

- Closes #49
- Closes #50
- Closes #51

## Test plan

- [x] Plugin builds locally (`just build`); `PixelProbe_Module` shows as active and links cleanly
- [ ] Smoke test in VCV Rack: load a PNG/JPG, sweep X/Y CV, verify Hue/Sat/Intensity follow the image; switch Polar ↔ Bipolar; save patch, reload, confirm image reloads from disk
- [ ] Confirm probe marker visually tracks the sampled point as Pan/Zoom change
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)