### PR TITLE
Fix gate_response false failure on percussive voices

### DIFF
--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -339,17 +339,29 @@ def test_gate_response(module_name: str, tmp_dir: Path) -> TestResult:
     stats_no_gate = extract_audio_stats(audio_no_gate)
     stats_with_gate = extract_audio_stats(audio_with_gate)
 
-    # Check if there's a significant difference
+    # Check if there's a significant difference.
+    #
+    # RMS alone is averaged over the whole render, so a percussive voice that
+    # fires one decaying hit scores far lower than a sustained one even though
+    # the gate clearly works. Matter, for example, goes from digital silence at
+    # gate=0 to a 0.167 peak at gate=10, yet only shifts RMS by 0.0056 over 2s.
+    # Peak catches that; RMS still catches sustained voices whose peak barely
+    # moves. A gate that genuinely does nothing moves neither.
     rms_diff = abs(stats_with_gate["rms"] - stats_no_gate["rms"])
+    peak_diff = abs(stats_with_gate["peak"] - stats_no_gate["peak"])
 
-    if rms_diff < 0.01:
+    if rms_diff < 0.01 and peak_diff < 0.01:
         return TestResult("gate_response", False,
-                         f"Gate has no effect on output (RMS diff: {rms_diff:.4f})",
+                         f"Gate has no effect on output "
+                         f"(RMS diff: {rms_diff:.4f}, peak diff: {peak_diff:.4f})",
                          {"rms_no_gate": stats_no_gate["rms"],
-                          "rms_with_gate": stats_with_gate["rms"]})
+                          "rms_with_gate": stats_with_gate["rms"],
+                          "peak_no_gate": stats_no_gate["peak"],
+                          "peak_with_gate": stats_with_gate["peak"]})
 
     return TestResult("gate_response", True,
-                     f"Gate affects output (RMS diff: {rms_diff:.4f})")
+                     f"Gate affects output (RMS diff: {rms_diff:.4f}, "
+                     f"peak diff: {peak_diff:.4f})")
 
 
 def test_parameter_sensitivity(module_name: str, tmp_dir: Path, exclude_params: list[str] | None = None) -> TestResult:


### PR DESCRIPTION
`Stage 4: Validate Audio Quality` is a required status check on `main`, and it has been failing since at least the #60 merge on `Matter / gate_response`. That blocks every PR from merging, including #61 and #62.

## Matter is not broken

The gate works exactly as it should. Rendered with `--no-auto-gate`:

| | peak | rms |
|---|---|---|
| `gate=0` | 0.00000 | 0.00000 |
| `gate=10` | 0.16714 | 0.00557 |

Digital silence versus a clean strike.

## The test was measuring the wrong thing

`test_gate_response` compared RMS across the whole render and failed below a 0.01 threshold. RMS is an average, so a percussive voice that fires one decaying hit scores far lower than a sustained one even when the gate is working. Matter shifts RMS by only 0.0056 over 2 seconds, just under the line.

## The fix

Compare peak as well, and fail only when neither RMS nor peak moves:

- Percussive voices are caught by peak.
- Sustained voices whose peak barely changes are still caught by RMS.
- A gate that genuinely does nothing moves neither, so a real regression still fails.

This adds an OR condition, so it can only turn failures into passes. No module that passed before can start failing as a result.

## Verification

Locally: `Matter`, `PluckedString`, `ModalBell` and `ChaosFlute` all pass. The full suite runs in CI here.

Once this lands, #61 and #62 should go green.