### PR TITLE
Rebase of fix/bug-issues-10-12-21 (analysis: recommend closing)

### DIFF
--- a/src/modules/Matter/matter.dsp
+++ b/src/modules/Matter/matter.dsp
@@ -74,18 +74,19 @@ gain(1) = min(1.0, 0.5 + sin(position * ma.PI));
 gain(2) = position;
 gain(3) = position * position;
 
-// Q factor based on decay
-q = 40 * decay;
+// Q factor based on decay (reduced max Q to prevent resonant buildup)
+q = 25 * decay;
 
 // Safe resonant bandpass
 safe_resonbp(freq, q_val, g) = fi.resonbp(freq, max(1, q_val), g);
 
-// The modal bank: 4 parallel resonators
+// The modal bank: 4 parallel resonators with normalized gains
+// Total gain budget ~1.0 to prevent summation overload
 block_sound = mallet <:
-    safe_resonbp(f(0), q, gain(0)),
-    safe_resonbp(f(1), q * 0.8, gain(1) * 0.7),
-    safe_resonbp(f(2), q * 0.6, gain(2) * 0.5),
-    safe_resonbp(f(3), q * 0.4, gain(3) * 0.3)
+    safe_resonbp(f(0), q, gain(0) * 0.4),
+    safe_resonbp(f(1), q * 0.8, gain(1) * 0.28),
+    safe_resonbp(f(2), q * 0.6, gain(2) * 0.2),
+    safe_resonbp(f(3), q * 0.4, gain(3) * 0.12)
     :> _;
 
 // ==========================================================
@@ -96,8 +97,8 @@ block_sound = mallet <:
 tube_freq = freq_base * tube_len;
 tube_samps = max(2, min(4000, ma.SR / tube_freq));
 
-// Simple waveguide: delay with lowpass feedback
-tube_algo = (+ : de.fdelay(4096, tube_samps) : fi.lowpass(1, 3000)) ~ *(0.9);
+// Simple waveguide: delay with lowpass feedback (reduced feedback to prevent energy buildup)
+tube_algo = (+ : de.fdelay(4096, tube_samps) : fi.lowpass(1, 3000)) ~ *(0.85);
 
 // ==========================================================
 // OUTPUT


### PR DESCRIPTION
Rebase of `581b696` (27 Feb) onto current main, as requested. Raised as a **draft** because the result is a regression and I do not think it should merge. The analysis is the deliverable here.

## Two of the three fixes no longer apply

**#21, Euclogic LFO range: moot.** The fix divided by `(steps-1)` so the last step reached 10V, across `Euclogic`, `Euclogic2` and `Euclogic3`. Those modules were split into the EucSeq chain in #41, and the LFO output no longer exists. There is no `LFO_OUTPUT` anywhere in `src/modules/EucSeq` or `src/common/euclogic`. All three files conflicted as modify/delete.

**#10, ACID9Voice grit: superseded.** Merged PR #14 already retuned the same lines, with different values:

| | this branch | main today |
|---|---|---|
| drive multiplier | 8x | 6x |
| asymmetric coefficient | 0.8 | 0.6 |
| drive compensation | 0.15 | 0.25 |

Resolved in main's favour.

**#12, Matter distortion: already done, differently.** Main implements all three of this branch's proposals by a cleaner route:

| Branch proposed | Main already does |
|---|---|
| Normalise per-resonator gains | `resonator_norm = *(0.35)` applied centrally |
| Soft limiter before the gain stage | `block_limited = block_sound : resonator_norm : soft_limit` |
| Reduce output gain from 8.0 | `output_gain = 4.0` |

## What survives, and why it is a regression

Only the hunks that auto-merged without conflict: per-resonator gains cut to 0.4/0.28/0.2/0.12, `q` from 40 to 25, and tube feedback 0.9 to 0.85. Those stack on top of main's existing `*(0.35)` normalisation, roughly 0.35 x 0.4 of the original level.

Measured with `test/audio_quality.py --module Matter`:

| Metric | main | this branch |
|--------|------|-------------|
| Peak amplitude | 0.080 | **0.028** |
| THD | 16.2% | **0.00%** |
| HNR | 11.9 dB | 8.4 dB |
| Dynamic range | 6.8 dB | **-24.5 dB** |

THD at 0.00% with a 0.028 peak means Matter has been attenuated into near-silence. Note main's peak of 0.080 is already below the 0.3 to 0.9 healthy band in CLAUDE.md, so Matter was quiet before this made it quieter.

## Recommendation

Close this draft and delete both `fix/bug-issues-10-12-21` and this rebase branch. Every issue it addressed has since been fixed or removed. If issues #10, #12 and #21 are still open, they can be closed as resolved by #14, #41 and the merged Matter work.

Worth noting separately: Matter's peak of 0.080 on main is low. That is a real observation but a different piece of work from this branch.

## Also stripped

The original commit carried a `Co-Authored-By: Claude` trailer. Removed while rewriting the message.