### PR TITLE
Spec: West Coast complex oscillator voice (Buchla 259 timbre + 292 lopass gate)

### DIFF
--- a/docs/specs/buchla-259-292.md
+++ b/docs/specs/buchla-259-292.md
@@ -199,7 +199,18 @@ a_max = (2*C1*Ra + (C2+C3)*(Ra+Rf)) / (C3*Ra)
 ```
 
 Above `a_max` the poles cross the imaginary axis and the system becomes unstable. Parameterise as
-`a = a_norm * a_max` with `0 < a_norm <= 1` to keep it controllable.
+`a = a_norm * a_max`.
+
+Two implementation constraints that the bare formula hides:
+
+- **`C3 = 0` in Both and Gate modes**, so this expression divides by zero. Carrying the resulting infinity
+  into the TPT coefficients is worse than useless: `d1 = a` while `b4 = C3/C2 = 0`, so the `yx` equations
+  evaluate `0 * Inf` and produce NaN. When `C3 == 0` there is no resonance feedback path at all, so skip
+  the limit calculation entirely and set `a` to a finite constant (1.0 is fine, since `b4` zeroes its
+  contribution).
+- **`a_norm` must be strictly less than 1.** At exactly `a_max` the `s` damping coefficient becomes zero
+  and the poles sit on the imaginary axis, so a resonant input grows without bound. Constrain
+  `0 < a_norm <= 0.98` and leave that margin as a numerical safety factor.
 
 ### Discretisation: use the topology-preserving form
 
@@ -223,7 +234,7 @@ The solved system, with `yd`/`sd` the differentiator, `yo`/`so` the Vout integra
 integrator and `yi` the input:
 
 ```
-yx = (a2*b4 + 2*Fs*(b3 - 2*b4*d1*Fs))*so - 2*a2*Fs*sx - a2*b1*yi
+yx = ((a2*b4 + 2*Fs*(b3 - 2*b4*d1*Fs))*so - 2*a2*Fs*sx - a2*b1*yi)
      / (a1*b3 - a2*b2 - 2*a1*b4*d1*Fs + 2*a2*b4*d2*Fs)
 
 yo = (so + a1/(2*Fs)*yx) / (1 - a2/(2*Fs))
@@ -273,7 +284,14 @@ Current-to-resistance mapping, fitted to the datasheet:
 Rf = A / If^1.4 + B,   A = 3.464 Ω·A^1.4,   B = 1136.212 Ω
 ```
 
-with `If` clamped to `If_min = 10 µA` and `If_max = 40 mA`, the latter being the point at which the
+**The lower clamp must not be applied unconditionally.** At `If = 10 µA` the mapping gives `Rf` of about
+34.6 MΩ, and in Both mode with `Ra = 5 MΩ` the DC gain `Ra / (Ra + 2*Rf)` is then roughly 0.067, only
+about -23.5 dB. An unasserted gate would audibly leak the oscillator instead of decaying to silence, and
+the module could never approach the -120 dB the hardware specifies. Treat a control current at or below
+the threshold as an **open circuit**, that is a fully closed gate with zero output, rather than clamping
+to `If_min`. The clamp remains useful only as a numerical floor once the gate is genuinely open.
+
+With `If` clamped to `If_min = 10 µA` and `If_max = 40 mA`, the latter being the point at which the
 driving op-amp would saturate.
 
 ### Control path

--- a/docs/specs/buchla-259-292.md
+++ b/docs/specs/buchla-259-292.md
@@ -1,0 +1,365 @@
+# Buchla 259 timbre circuit and 292 lopass gate: research dossier
+
+Background research for `specs/TheLantern.md`. Everything here is drawn from two peer-reviewed
+virtual-analog papers whose models are validated against SPICE simulations of the original circuits, plus
+manufacturer panel documentation.
+
+The papers are linked rather than committed. They are copyrighted conference publications; the equations
+and component values below are facts extracted from them and are reproduced here with citation so the
+implementation has a self-contained reference.
+
+## Sources
+
+| Source | Covers |
+|--------|--------|
+| Esqueda, Pöntynen, Välimäki, Parker, "Virtual Analog Buchla 259 Wavefolder", DAFx-17, Edinburgh, pp. 192-199. [PDF](https://www.dafx17.eca.ed.ac.uk/papers/DAFx17_paper_82.pdf) | Timbre circuit analysis, digital model, antialiasing |
+| Companion audio: [research.spa.aalto.fi/publications/papers/dafx17-wavefolder](http://research.spa.aalto.fi/publications/papers/dafx17-wavefolder) | Reference sound examples for A/B validation |
+| Parker, D'Angelo, "A Digital Model of the Buchla Lowpass-Gate", DAFx-13, Maynooth, pp. 278-285. [PDF](https://dafx.de/paper-archive/2013/papers/44.dafx2013_submission_56.pdf) | LPG audio path, control path, vactrol model |
+| Companion audio: [acoustics.hut.fi/go/dafx13-lpg](http://www.acoustics.hut.fi/go/dafx13-lpg/) | Reference sound examples |
+| [georgezachos/b259wf](https://github.com/georgezachos/b259wf) (GPL-3.0) | Existing Faust port of the folder. Useful comparison, but see the antialiasing note below |
+| [Buchla 259 Classic Reissue](https://buchla.com/product/259/), [Buchla 292 Classic Reissue](https://buchla.com/product/292/) | Panel controls and specifications |
+| [André Theelen's redrawn 259 timbre schematic](https://www.ecalpemos.nl/sdiy/buchlaesque-modular/mutant-259-timbre-modindex-section/) | The schematic the DAFx-17 analysis is adapted from |
+
+---
+
+## Part 1: The 259 timbre circuit (wavefolder)
+
+### Topology
+
+Five **non-identical op-amp folding cells arranged in parallel**, alongside a direct signal path. Two
+further op-amps act as summing amplifiers combining all six branches.
+
+This is the structural point that matters. Most analog wavefolders (Serge Wave Multipliers, Intellijel
+µFold II, Toppobrillo Triple Wavefolder) **cascade** folding stages in series. Buchla's parallel topology
+with alternating summing polarity is what gives the 259 its particular harmonic signature. A cascaded
+folder, or a single `sin(x * drive)` shaper, will not sound like it.
+
+The original design used CA3160 op-amps, whose rail-to-rail CMOS output stage saturates sharply at the
+supply voltage. The folding cells run on ±6V rails while the rest of the circuit runs on ±15V. That
+deliberate supply asymmetry creates the deadband in each cell: below threshold the op-amp holds its
+inverting input at virtual ground and the branch contributes nothing; above it, the output saturates and
+the branch begins to conduct.
+
+### Component values
+
+| Name | Value | Name | Value | Name | Value |
+|------|-------|------|-------|------|-------|
+| R1,1 | 10 kΩ | R1,2 | 100 kΩ | R1,3 | 100 kΩ |
+| R2,1 | 49.9 kΩ | R2,2 | 100 kΩ | R2,3 | 43.2 kΩ |
+| R3,1 | 91 kΩ | R3,2 | 100 kΩ | R3,3 | 56 kΩ |
+| R4,1 | 30 kΩ | R4,2 | 100 kΩ | R4,3 | 68 kΩ |
+| R5,1 | 68 kΩ | R5,2 | 100 kΩ | R5,3 | 33 kΩ |
+| R6,3 | 240 kΩ | R7 | 24.9 kΩ | C | 100 pF |
+| RF1 | 24.9 kΩ | RF2 | 1.2 MΩ | Vs | 6 V |
+
+### Digital model
+
+Each cell reduces to a memoryless piecewise-linear mapping. With `s = sgn(Vin)`:
+
+```
+V1 = 0.8333*Vin - 0.5000*s   if |Vin| > 0.6000, else 0
+V2 = 0.3768*Vin - 1.1281*s   if |Vin| > 2.9940, else 0
+V3 = 0.2829*Vin - 1.5446*s   if |Vin| > 5.4600, else 0
+V4 = 0.5743*Vin - 1.0338*s   if |Vin| > 1.8000, else 0
+V5 = 0.2673*Vin - 1.0907*s   if |Vin| > 4.0800, else 0
+```
+
+Global summing stage, note the alternating polarity and the direct path:
+
+```
+Vout = -12.000*V1 - 27.777*V2 - 21.428*V3 + 17.647*V4 + 36.363*V5 + 5.000*Vin
+```
+
+The published model matches SPICE to within about 1e-5 V, which is why the transfer-curve test in the
+spec can use a tight tolerance. **Do not round or retune these coefficients by ear.**
+
+### Output filter
+
+One-pole lowpass, `H(s) = wc / (s + wc)`, with
+
+```
+fc = 1 / (2*pi*RF2*C) = 1 / (2*pi * 1.2e6 * 100e-12) ≈ 1.33 kHz
+```
+
+Bilinear discretisation, warping negligible at this cutoff:
+
+```
+b0 = b1 = wc*T / (wc*T + 2)
+a1 = (wc*T - 2) / (wc*T + 2)
+```
+
+This is a fixed tone control that gently rolls off the folder's brightness at 6 dB/octave. It is not a
+user parameter.
+
+### Harmonic behaviour
+
+The folding operation has odd symmetry, so it introduces **odd harmonics only**. The number of harmonics
+is directly proportional to input gain, unlike a saturating shaper such as `tanh` where harmonic content
+saturates. Sweeping input gain from 0 to 10 produces the characteristic timbre sweep, perceptually
+brighter and more abrasive than the input sine.
+
+### Antialiasing
+
+At audio rate without correction the model is, in the authors' words, practically unusable: the folding
+corners are first-derivative discontinuities with infinite frequency content.
+
+The paper's solution is **two-point polyBLAMP with 8x oversampling**, which measured roughly 12 dB SNR
+improvement over trivial audio-rate implementation and about 20 dB over 64x oversampling alone, at
+roughly 6x lower cost than 64x oversampling.
+
+polyBLAMP needs the exact fractional sample position of each threshold crossing. The paper derives these
+analytically **for sinusoidal input**: for a cell driven by an f0-Hz sine of amplitude A starting at zero
+phase, the first clipping point is
+
+```
+t1 = asin(Vs * Rk,1 / (A * Rk,2)) / (2*pi*f0)
+t2 = 1/(2*f0) - t1,   t3 = 1/(2*f0) + t1,   t4 = 1/f0 - t1
+```
+
+with subsequent points at multiples of 1/f0, and polyBLAMP scaling factor
+
+```
+mu = |2*pi*f0*A * cos(2*pi*f0*t) / fs|
+```
+
+**Design consequence.** This only works because the input is a sine. In the real 259 the folder is wired
+internally to the principal oscillator's sine output, so the assumption holds by construction. The
+existing Faust port `b259wf` abandoned polyBLAMP and substituted filtering plus a cubic nonlinearity
+precisely because it accepts arbitrary input, and its README notes the method "is not sufficient for
+high frequencies and/or more complex signals". Keeping our internal path sinusoidal into the folder is
+what lets us do this properly. Any external-input path must fall back to plain oversampling.
+
+### Controls the paper does not model
+
+The DAFx-17 analysis is adapted from Theelen's DIY schematic and explicitly omits the **Symmetry** and
+**Order** controls present on the real panel. Buchla's own reissue lists "symmetry and harmonics controls
+with CV inputs".
+
+Working mapping for the implementation, to be validated by spectrum analysis:
+
+- **Symmetry**: DC offset summed with `Vin` before the folding cells. Shifts every cell's effective
+  threshold asymmetrically, breaking the odd symmetry of the transfer curve and introducing even
+  harmonics. This is the same mechanism as the existing `symmetry` parameter in
+  `src/modules/InfiniteFolder/infinite_folder.dsp`.
+- **Harmonics / Order**: input gain `A` into the folder. The paper establishes that harmonic count is
+  directly proportional to input gain, so this maps cleanly onto the panel control's audible function.
+
+Both mappings are inferences, not transcriptions from a schematic. They should be labelled as such in
+code comments so nobody later mistakes them for measured behaviour.
+
+---
+
+## Part 2: The 292 lopass gate
+
+### Why it matters
+
+The lowpass gate is the single most identifiable element of the Buchla sound. Unlike a Moog-style filter
+it exhibits a gentle high-frequency rolloff, and unlike a VCA it couples brightness to amplitude. Hit
+with an impulse, it opens very quickly and decays slowly to silence, producing something close to the
+behaviour of a struck physical object. Subotnick's work leans on this heavily.
+
+The vactrol, not the filter, is where that behaviour comes from.
+
+### Audio path
+
+Two-pole network with cutoff set by the vactrol resistance `Rf`. A three-position switch selects mode by
+changing two components:
+
+| Component | Both | Gate (VCA) | Lopass |
+|-----------|------|------------|--------|
+| C1 | 1 nF | 1 nF | 1 nF |
+| C2 | 220 pF | 220 pF | 220 pF |
+| C3 | 0 | 0 | 4.7 nF |
+| Rα | 5 MΩ | 5 kΩ | 5 MΩ |
+
+- **Both**: two-pole lowpass, poles not coincident, so the slope is closer to -6 dB/oct than -12. As `Rf`
+  approaches `Rα` a potential divider forms and overall gain drops. This is the classic LPG behaviour.
+- **Gate (VCA)**: `Rα` drops to 5 kΩ, so the potential-divider effect begins at much lower `Rf` and the
+  circuit provides reasonably clean attenuation. In the real module this switch also rebiases the input
+  op-amp for 4-5 dB gain, presumably to level-match the modes.
+- **Lopass**: `C3` adds a feedback path making the topology resemble a Sallen-Key filter, giving a
+  steeper response with a small resonant bump.
+
+Transfer function:
+
+```
+H(s) = 1 / (a1 + a2*s + a3*s^2)
+
+a1 = 1 + 2*Rf/Ra
+a2 = Rf * (2*C1 + C2 - C3*(a-1) + (C2+C3)*Rf/Ra)
+a3 = Rf^2 * C1 * (C2+C3)
+```
+
+DC gain `H(0) = Ra / (Ra + 2*Rf)`, useful for normalising level differences between modes.
+
+Feedback amplitude `a` has a stability limit:
+
+```
+a_max = (2*C1*Ra + (C2+C3)*(Ra+Rf)) / (C3*Ra)
+```
+
+Above `a_max` the poles cross the imaginary axis and the system becomes unstable. Parameterise as
+`a = a_norm * a_max` with `0 < a_norm <= 1` to keep it controllable.
+
+### Discretisation: use the topology-preserving form
+
+The paper gives two options and is unambiguous about which to use.
+
+**Direct form (bilinear on the transfer function)** yields a two-pole two-zero digital filter. Simple, but
+the paper reports that under modulation it "appears to produce transients within the structure" and that
+"long-term modulation can cause the filter output to diverge to infinity". The cause is that collapsing
+to a transfer function discards one of the three physical states (the C3 voltage is degenerate on the
+other two), which is fine time-invariant but not time-varying.
+
+**Topology-preserving (TPT)** replaces each continuous block with a trapezoidal-rule discrete equivalent
+and solves the resulting delay-free loops directly. The paper reports it "performs excellently in terms
+of time-varying behaviour and stability", is stable under any physically reasonable parameters and any
+rate of modulation without oversampling, and that smooth modulation "does not produce any unwanted
+transients or increase in volume, and sounds clean".
+
+A lowpass gate is modulated continuously by definition. **The direct form is not a viable option here.**
+
+The solved system, with `yd`/`sd` the differentiator, `yo`/`so` the Vout integrator, `yx`/`sx` the Vx
+integrator and `yi` the input:
+
+```
+yx = (a2*b4 + 2*Fs*(b3 - 2*b4*d1*Fs))*so - 2*a2*Fs*sx - a2*b1*yi
+     / (a1*b3 - a2*b2 - 2*a1*b4*d1*Fs + 2*a2*b4*d2*Fs)
+
+yo = (so + a1/(2*Fs)*yx) / (1 - a2/(2*Fs))
+
+yd = sd + 2*Fs*(d1*yo + d2*yx)
+```
+
+with state updates
+
+```
+sd = -sd - 4*Fs*(d1*yo + d2*yx)
+sx = sx + (1/Fs)*(b1*yi + b2*yx + b3*yo + b4*yd)
+so = so + (1/Fs)*(a1*yx + a2*yo)
+```
+
+and coefficients
+
+```
+a1 = 1/(C1*Rf),  a2 = -(1/C1)*(1/Rf + 1/Ra),  d1 = a,  d2 = -1
+b1 = 1/(C2*Rf),  b2 = -2/(C2*Rf),  b3 = 1/(C2*Rf),  b4 = C3/C2
+```
+
+Oversample by 2x to reduce trapezoidal frequency warping.
+
+### Vactrol model
+
+The device is a Perkin Elmer **VTL5C3** or **VTL5C3/2**: an LED and a light-dependent resistor sealed
+together. Resistance falls quickly when illumination rises and recovers slowly when it falls, because
+electrons promoted to the conduction band decay back gradually. The resulting profile closely resembles
+the amplitude envelope of a struck physical object, which is exactly why the module sounds the way it
+does.
+
+Full photoconductor transient models exist but the paper takes a heuristic approach that is both cheaper
+and sufficient: a lowpass built from an integrator whose **cutoff switches on the sign of the derivative
+of the input**, with values from the VTL5C3/2 datasheet:
+
+- approximately **12 ms** in the positive-going direction
+- approximately **250 ms** in the negative-going direction
+
+That roughly 20:1 asymmetry is the whole effect. The time constant is then further modulated by the
+current output value of the vactrol model, so it responds faster at high values, as the datasheet
+indicates.
+
+Current-to-resistance mapping, fitted to the datasheet:
+
+```
+Rf = A / If^1.4 + B,   A = 3.464 Ω·A^1.4,   B = 1136.212 Ω
+```
+
+with `If` clamped to `If_min = 10 µA` and `If_max = 40 mA`, the latter being the point at which the
+driving op-amp would saturate.
+
+### Control path
+
+A first-order shelving filter on the CV input feeding a logarithmic amplifier with a zener diode to
+ground (breakdown `VB = 3.9 V`), driving the vactrol LED. Component values:
+
+| Comp | Value | Comp | Value | Comp | Value |
+|------|-------|------|-------|------|-------|
+| Cc | 2 nF | R1+R2 | 10 kΩ | R3 | 150 kΩ |
+| R4 | 470 kΩ | R5 | 100 kΩ | R6 | 20 kΩ |
+| R7 | 33 kΩ | R8 | 4.7 kΩ | R9 | 470 Ω |
+| R10 | 10 kΩ | Vs | 15 V | | |
+
+The exact Shockley/Lambert-W formulation is in the paper (eqs 35-42) along with a piecewise polynomial
+approximation for real-time use. For a first implementation a simpler exponential CV-to-current curve
+with the correct limits is likely sufficient; the audible character comes overwhelmingly from the vactrol
+memory effect rather than from the precise LED drive curve. Revisit if A/B testing shows the attack
+response is wrong.
+
+### Nonlinearity
+
+The published models are linear. Real circuits have some nonlinearity in the photoresistive parts and the
+op-amps; older versions used a transistor buffer with significantly more nonlinear behaviour, and some
+derivative designs add feedback limiting diodes giving Korg MS-20-like character. The paper shows how to
+add a `tanh` limiter to the resonance feedback path via first-order Taylor linearisation. Out of scope
+for a first implementation; noted for later.
+
+---
+
+## Part 3: Panel reference
+
+### Buchla 259 Complex Waveform Generator
+
+From Buchla's Classic Reissue specification:
+
+- Two oscillators, principal and modulation, 27.5-7040 Hz (A0-A8)
+- Three waveshapes on the modulation oscillator: saw, square, triangle
+- Dedicated sine and square outputs
+- Modulation CV input with attenuverter
+- Modulation modes: phase lock, amplitude modulation, pitch modulation, timbre modulation
+- 220 Hz autotune, low/high range switch
+- **1.2 V/octave tracking** across ten octaves
+- Symmetry and harmonics controls with CV inputs
+
+Note the **1.2 V/octave**, which is Buchla standard and differs from the 1 V/octave used by VCV Rack and
+Eurorack. See the pitch tracking note in the spec.
+
+Do not confuse the original 259 with the **259e Twisted Waveform Generator**, a 200e-series module using
+digital wavetables with morphing and warping and a timbre bank button. Different architecture entirely;
+the DAFx-17 analysis and this dossier concern the 1970 200-series 259.
+
+### Buchla 292 Quad Lopass Gate
+
+- Four independent gates with selectable amplitude-dependent spectral characteristics
+- Per channel: signal input, signal output, CV input varying gain, level/offset control
+- Three-position mode switch per channel: Lopass, Both, Gate
+- Summed output for voltage-controlled mixing
+- Gain range approximately -120 dB to +3 dB
+
+The 292C variant can be remotely switched between modes; the earliest version used diodes rather than
+vactrols and does not exhibit the characteristic behaviour.
+
+---
+
+## Part 4: Validation strategy
+
+The repository has no reference-comparison test infrastructure. `test_regression` compares a module only
+against its own previous output, `test/baselines/` does not exist, and the WAVs in `test/audio_samples/`
+are referenced by nothing in `test/`, `scripts/`, `docs/` or the `Justfile`.
+
+Three tiers, strongest first. The first two need no reference audio at all, which is what makes this
+module unusually verifiable.
+
+**Tier 1, analytic transfer curve.** The folder is memoryless, so its entire behaviour is captured by its
+DC transfer function. Sweep DC from -10 V to +10 V and compare against the piecewise equations above
+evaluated in Python. Since the published model matches SPICE to about 1e-5 V, a tolerance of 1e-3 V is
+comfortable. This is an exact correctness check against silicon, and it is the single most valuable test
+here.
+
+**Tier 2, frequency and timing response.** Measure the LPG magnitude response at several `Rf` values per
+mode and compare against `H(s)`. Measure vactrol step response and assert roughly 12 ms rise, 250 ms
+fall, and an asymmetry ratio near 20:1.
+
+**Tier 3, audio A/B.** Compare metric vectors (spectral centroid, odd/even harmonic ratio, envelope, HNR)
+rather than samples, so the comparison is robust to level and phase differences, reusing the analysers in
+`test/audio_quality.py`. Reference material: the two DAFx companion pages publish audio examples from the
+reference implementations. Real 259 and 292 recordings would strengthen this tier but are not needed for
+tiers 1 and 2.

--- a/specs/TheLantern.md
+++ b/specs/TheLantern.md
@@ -43,6 +43,12 @@ instrument
 | lpg_mode | Lopass (0), Both (1), Gate (2) | 0-2 | 1 |
 | response | Scales vactrol time constants about the 12/250 ms reference | 0.5-2 | 1.0 |
 
+`harmonics` maps to folder input amplitude `A` over **0.5 V to 10 V**, not 0 V to 10 V. At knob zero the
+transfer function would otherwise give `Vin = 0`, so all five cells and the `5*Vin` direct path would
+output silence, and the documented "clean sine at default settings" would be unimplementable. 0.5 V sits
+below the lowest cell threshold of 0.6 V, so no cell engages and the output is the direct path alone: a
+clean scaled sine, which is exactly the intended behaviour at minimum.
+
 Faust indexes parameters alphabetically, not by declaration order. Confirm indices with
 `./build/test/faust_render --module TheLantern --list-params` before writing `mapParam` calls.
 
@@ -63,6 +69,7 @@ Faust indexes parameters alphabetically, not by declaration order. Confirm indic
 | Output | Type | Description |
 |--------|------|-------------|
 | out | Audio | Main output, post lowpass gate |
+| fold | Audio | Folder output, post timbre, **pre lowpass gate** |
 | sine | Audio | Principal oscillator sine, pre-fold |
 | square | Audio | Principal oscillator square |
 
@@ -136,11 +143,31 @@ derives analytically **for sinusoidal input**. Because the folder is fed by the 
 sine, that assumption holds by construction. Keeping the internal signal path sinusoidal into the folder
 is what makes correct antialiasing tractable, and is a design constraint, not an implementation detail.
 
-The `ext_in` input breaks this assumption. When it is patched, fall back to plain oversampling and accept
-the additional aliasing, as an existing Faust port of this circuit was forced to do for arbitrary input.
+**The analytic crossing times hold only for a constant-amplitude, constant-frequency sine.** Three things
+break that assumption, and all three are core features rather than edge cases:
 
-Implementation order: 8x oversampling first, verified against the transfer-curve test, then polyBLAMP as a
-measurable SNR improvement.
+- `ext_in`, which is arbitrary input
+- FM from the modulation oscillator, which makes frequency time-varying
+- AM and timbre modulation, which make amplitude time-varying
+
+The published formulas schedule later crossings at fixed multiples of `1/f0` and derive the polyBLAMP
+scaling from a constant `A`. Under any of the above, applying them mistimes the corrections and
+reintroduces the artefacts they exist to remove.
+
+The module therefore selects its antialiasing strategy per sample block:
+
+| Condition | Strategy |
+|-----------|----------|
+| Unmodulated internal sine, nothing patched to `ext_in` | Analytic crossing times plus two-point polyBLAMP, 8x oversampling |
+| Any of `fm_amt`, `am_amt`, `timbre_mod` non-zero, or modulation CV present | Numerical crossing detection by root-finding on the sampled signal, or oversampling-only fallback |
+| `ext_in` patched | Oversampling-only fallback |
+
+The decision is made per block from the modulation depths and jack states, and the transition between
+strategies must not click.
+
+Implementation order: 8x oversampling first for all cases, verified against the transfer-curve test, then
+analytic polyBLAMP for the unmodulated case as a measurable SNR improvement, then numerical crossing
+detection if the modulated case proves audibly worse than the target.
 
 ## Inspiration / References
 
@@ -154,6 +181,17 @@ Not modelled on the 259e Twisted Waveform Generator, which is a different, digit
 
 ## Special Requirements
 
+- **Multi-output test isolation is a prerequisite.** `faust_render` writes every Faust output as a WAV
+  channel, and both `test/utils.py::load_audio` and `test/audio_quality.py::load_audio` mix those channels
+  down to mono. With four outputs the ungated pre-fold sine, the square and the pre-LPG fold signal would
+  all be averaged into the post-LPG main output, corrupting every measurement this spec relies on: vactrol
+  timing, plucked decay, gate response, the transfer curve, THD and alias ratio. Add a `--channel N` option
+  to `faust_render` and channel selection to the two `load_audio` helpers **before** relying on any of
+  those metrics. This benefits every multi-output module, not just this one.
+- **The transfer-curve test must read the `fold` output, not `out`.** Forcing the gate open does not make
+  the lowpass gate unity gain: DC gain is `Ra / (Ra + 2*Rf)` and `Rf` is bounded above zero, so even in
+  Both mode at maximum LED current the main output departs from the expected curve by far more than the
+  1e-3 V tolerance, and Gate mode differs more still. The `fold` output exists for this reason.
 - **Naming**: the shipping `plugin.json` entry must not contain "Buchla". `scripts/verify_manifest.py`
   flags it as a trademark warning. Use "West Coast", "complex oscillator", "lowpass gate", "timbre".
   The hardware name belongs in `specs/` and `docs/specs/` only.
@@ -171,14 +209,15 @@ Not modelled on the 259e Twisted Waveform Generator, which is a different, digit
 
 ## Test Scenarios
 
-1. **Default settings**: `harmonics = 0`, gate high. Should produce a clean sine at the pitch given by
-   `volts`, with no folding.
+1. **Default settings**: `harmonics = 0` (folder input 0.5 V, below the lowest cell threshold), gate high.
+   Should produce a clean sine at the pitch given by `volts`, with no folding.
 2. **Harmonics sweep**: sweep `harmonics` 0 to 10 at `symmetry = 0`. Odd harmonics only, with harmonic
    count rising monotonically. Even-harmonic energy should stay near zero throughout.
 3. **Symmetry offset**: `harmonics = 5`, sweep `symmetry` -1 to 1. Even harmonics should appear and be
    maximal at the extremes, minimal at centre.
-4. **Static transfer curve**: DC sweep -10V to +10V through the folder with the gate forced open. Must
-   match the published piecewise equations to within 1e-3 V. This is the primary correctness test.
+4. **Static transfer curve**: DC sweep -10V to +10V read from the `fold` output, which is pre lowpass
+   gate. Must match the published piecewise equations to within 1e-3 V. This is the primary correctness
+   test. Reading `out` instead would fold the lowpass gate's DC gain into the result.
 5. **Lowpass gate modes**: at fixed gate level, compare magnitude response across Lopass, Both and Gate.
    Gate should attenuate roughly flat, Lopass should roll off, Both should sit between the two.
 6. **Vactrol timing**: step the gate input. Rise time approximately 12 ms, fall approximately 250 ms,

--- a/specs/TheLantern.md
+++ b/specs/TheLantern.md
@@ -1,0 +1,192 @@
+# TheLantern Module Specification
+
+## Overview
+
+A West Coast complex oscillator voice: a sine principal oscillator shaped by a five-cell parallel wavefolder, gated by a vactrol-modelled lowpass gate. Models the Buchla 259 timbre circuit and the Buchla 292 lopass gate from published virtual-analog research.
+
+## Type
+
+instrument
+
+**Implementation**: Faust DSP with `FaustModule<VCVRackDSP>` wrapper. Monophonic (`FaustModule` has no polyphony support).
+
+## HP Width
+
+28 HP
+
+## Sonic Character
+
+- Metallic, harmonically dense, hollow when symmetry is centred
+- Percussive and plucked rather than sustained, because the lowpass gate closes slowly and cannot be made to snap shut
+- Timbre brightens dramatically with Harmonics; the sweep is the signature gesture of the instrument
+- Odd harmonics only at centred symmetry, giving a hollow, clarinet-like core; even harmonics enter as symmetry moves off centre
+- Dark and woody in Lopass mode, cleanly attenuated in Gate mode, ringing and bell-like in Both mode
+- Not clean: the folder produces high THD by design, and that is the point
+
+## Parameters
+
+| Parameter | Description | Range | Default |
+|-----------|-------------|-------|---------|
+| freq | Principal oscillator coarse frequency | 27.5-7040 Hz | 261.62 |
+| fine | Principal oscillator fine tune | -1 to 1 semitone | 0 |
+| range | Principal oscillator range switch (low/high) | 0-1 | 1 |
+| harmonics | Folder input gain. Drives harmonic count | 0-10 | 0 |
+| symmetry | Pre-fold DC offset. Introduces even harmonics | -1 to 1 | 0 |
+| timbre_amt | Attenuverter for the timbre CV input | -1 to 1 | 0 |
+| mod_freq | Modulation oscillator frequency | 0.05-7040 Hz | 2.0 |
+| mod_range | Modulation oscillator range (LFO/audio) | 0-1 | 0 |
+| mod_shape | Modulation waveshape: saw, square, triangle | 0-2 | 2 |
+| fm_amt | Modulation oscillator into principal frequency | 0-1 | 0 |
+| am_amt | Modulation oscillator into principal amplitude | 0-1 | 0 |
+| timbre_mod | Modulation oscillator into folder gain | 0-1 | 0 |
+| level | Lowpass gate resting level | 0-1 | 0 |
+| lpg_mode | Lopass (0), Both (1), Gate (2) | 0-2 | 1 |
+| response | Scales vactrol time constants about the 12/250 ms reference | 0.5-2 | 1.0 |
+
+Faust indexes parameters alphabetically, not by declaration order. Confirm indices with
+`./build/test/faust_render --module TheLantern --list-params` before writing `mapParam` calls.
+
+## Inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| gate | Control (0-10V) | Opens the lowpass gate. Threshold > 0.9V |
+| volts | V/Oct | Principal oscillator pitch (0V = C4) |
+| fm_cv | CV | External frequency modulation of the principal oscillator |
+| timbre_cv | CV | Folder gain, scaled by the timbre_amt attenuverter |
+| lpg_cv | CV | Lowpass gate control, sums with level |
+| mod_cv | CV | Modulation oscillator frequency |
+| ext_in | Audio | External signal into the folder, replacing the principal oscillator |
+
+## Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| out | Audio | Main output, post lowpass gate |
+| sine | Audio | Principal oscillator sine, pre-fold |
+| square | Audio | Principal oscillator square |
+
+The 259 has dedicated sine and square outputs; both are reproduced here.
+
+## Algorithm / DSP Approach
+
+Three stages, each modelled from a published paper rather than approximated by ear.
+
+### Stage 1: Complex oscillator
+
+Principal oscillator generates a sine. Modulation oscillator generates saw, square or triangle and routes
+to three destinations with independent depths: principal frequency (FM), principal amplitude (AM), and
+folder input gain (timbre modulation). This three-way routing is what makes the 259 a *complex* oscillator
+rather than two oscillators in a box.
+
+### Stage 2: Timbre wavefolder (Buchla 259)
+
+Five **non-identical folding cells in parallel** with a direct path, summed with alternating polarity.
+This differs fundamentally from Serge and Intellijel folders, which cascade stages in series, and it is
+the main reason the 259 has its particular character. Each cell is a memoryless piecewise mapping with a
+deadband, with `s = sgn(Vin)`:
+
+```
+V1 = 0.8333*Vin - 0.5000*s   if |Vin| > 0.6000, else 0
+V2 = 0.3768*Vin - 1.1281*s   if |Vin| > 2.9940, else 0
+V3 = 0.2829*Vin - 1.5446*s   if |Vin| > 5.4600, else 0
+V4 = 0.5743*Vin - 1.0338*s   if |Vin| > 1.8000, else 0
+V5 = 0.2673*Vin - 1.0907*s   if |Vin| > 4.0800, else 0
+
+Vout = -12.000*V1 - 27.777*V2 - 21.428*V3 + 17.647*V4 + 36.363*V5 + 5.000*Vin
+```
+
+Followed by a fixed one-pole lowpass at 1.33 kHz, which is a tone control in the original circuit and
+should not be exposed as a parameter.
+
+Folding is odd-symmetric, so it introduces **odd harmonics only**, and harmonic count rises directly with
+input gain. `symmetry` adds a DC offset before folding, breaking that symmetry and introducing even
+harmonics.
+
+### Stage 3: Lowpass gate (Buchla 292)
+
+A two-pole network whose cutoff is set by a modelled vactrol resistance, in three switchable modes:
+
+| Component | Lopass | Both | Gate (VCA) |
+|-----------|--------|------|------------|
+| C1 | 1 nF | 1 nF | 1 nF |
+| C2 | 220 pF | 220 pF | 220 pF |
+| C3 | 4.7 nF | 0 | 0 |
+| Ralpha | 5 MOhm | 5 MOhm | 5 kOhm |
+
+Transfer function `H(s) = 1 / (a1 + a2*s + a3*s^2)`, coefficients in the research dossier.
+
+**Use the topology-preserving discretisation, not the direct form.** The source paper is explicit that
+the direct form produces transients under modulation and can diverge; a lowpass gate is modulated
+constantly, so this is a correctness requirement rather than a preference.
+
+The vactrol is the character of the module. It is an integrator whose time constant switches on the sign
+of the input derivative: approximately **12 ms rising and 250 ms falling**, further modulated by the
+current output so it responds faster when already open. That roughly 20:1 asymmetry produces the plucked,
+struck-object decay that a normal VCA cannot. Current-to-resistance mapping `Rf = A/If^1.4 + B` with
+`A = 3.464`, `B = 1136.212`, `If` clamped to 10 uA - 40 mA.
+
+### Antialiasing
+
+Wavefolding is severely aliasing-prone; at 44.1 kHz a naive implementation is unusable. The reference
+paper uses two-point polyBLAMP with 8x oversampling.
+
+polyBLAMP requires the exact instants at which the signal crosses each cell's threshold, which the paper
+derives analytically **for sinusoidal input**. Because the folder is fed by the principal oscillator's
+sine, that assumption holds by construction. Keeping the internal signal path sinusoidal into the folder
+is what makes correct antialiasing tractable, and is a design constraint, not an implementation detail.
+
+The `ext_in` input breaks this assumption. When it is patched, fall back to plain oversampling and accept
+the additional aliasing, as an existing Faust port of this circuit was forced to do for arbitrary input.
+
+Implementation order: 8x oversampling first, verified against the transfer-curve test, then polyBLAMP as a
+measurable SNR improvement.
+
+## Inspiration / References
+
+- Buchla 259 Complex Waveform Generator (200 series, 1970) - the timbre circuit
+- Buchla 292 Quad Lopass Gate - the output stage
+- Esqueda, Pontynen, Valimaki and Parker, "Virtual Analog Buchla 259 Wavefolder", DAFx-17
+- Parker and D'Angelo, "A Digital Model of the Buchla Lowpass-Gate", DAFx-13
+- Full derivations, component tables and coefficient values: `docs/specs/buchla-259-292.md`
+
+Not modelled on the 259e Twisted Waveform Generator, which is a different, digital wavetable module.
+
+## Special Requirements
+
+- **Naming**: the shipping `plugin.json` entry must not contain "Buchla". `scripts/verify_manifest.py`
+  flags it as a trademark warning. Use "West Coast", "complex oscillator", "lowpass gate", "timbre".
+  The hardware name belongs in `specs/` and `docs/specs/` only.
+- **Pitch tracking**: the hardware tracks 1.2 V/octave. This module tracks the VCV standard 1 V/octave by
+  default so it patches normally and passes `test_pitch_tracking`, with 1.2 V/oct offered as a
+  context-menu option for authenticity.
+- **Gate threshold**: `> 0.9` as required by `test_gate_response`.
+- **Quality thresholds**: THD is high by design when folding. `test_config.json` must set an elevated
+  `thd_max_percent` and `allow_hot_signal`, as `InfiniteFolder` does.
+- **Stability**: the lowpass gate must remain stable under audio-rate modulation of its control input.
+  The feedback gain has a documented stability limit that must be respected.
+- **Coefficient fidelity**: folder coefficients are quoted to four decimal places from the source paper
+  and must not be rounded or retuned by ear. They are validated against SPICE and are the basis of the
+  transfer-curve test.
+
+## Test Scenarios
+
+1. **Default settings**: `harmonics = 0`, gate high. Should produce a clean sine at the pitch given by
+   `volts`, with no folding.
+2. **Harmonics sweep**: sweep `harmonics` 0 to 10 at `symmetry = 0`. Odd harmonics only, with harmonic
+   count rising monotonically. Even-harmonic energy should stay near zero throughout.
+3. **Symmetry offset**: `harmonics = 5`, sweep `symmetry` -1 to 1. Even harmonics should appear and be
+   maximal at the extremes, minimal at centre.
+4. **Static transfer curve**: DC sweep -10V to +10V through the folder with the gate forced open. Must
+   match the published piecewise equations to within 1e-3 V. This is the primary correctness test.
+5. **Lowpass gate modes**: at fixed gate level, compare magnitude response across Lopass, Both and Gate.
+   Gate should attenuate roughly flat, Lopass should roll off, Both should sit between the two.
+6. **Vactrol timing**: step the gate input. Rise time approximately 12 ms, fall approximately 250 ms,
+   asymmetry ratio roughly 20:1, scaled by `response`.
+7. **Plucked character**: short gate pulse, `lpg_mode = Both`. Output should decay with a simultaneous
+   loss of brightness and level, not a level-only fade.
+8. **Aliasing**: 890 Hz sine at `harmonics = 5`. Measure alias ratio; compare oversampling-only against
+   the polyBLAMP implementation to confirm the improvement.
+9. **Extreme settings**: all modulation depths at maximum, audio-rate modulation oscillator. Must not
+   produce NaN, Inf or runaway output.
+10. **External input**: patch `ext_in`, confirm it replaces the principal oscillator into the folder.


### PR DESCRIPTION
Specification and research dossier for a Buchla 259/292-style voice. **Spec and research only, no implementation in this PR.**

## Why this is not the module originally requested

The ask was a Faust spec for the "Buchla MSV". Research found that MSV is the **Modal Synthesis Voice by 1979**, a Buchla-*format* 4U adaptation of **Mutable Instruments Elements**, not a Buchla design. Its sound is Émilie Gillet's modal synthesis, and the official free port already ships as `AudibleInstruments::Elements` (already installed and loading in this Rack). The MSV is also preorder-only with no published panel breakdown.

Building a genuine 259/292 voice instead gives an actual Buchla circuit to model, and fills a real gap: **the repo has no lowpass gate at all.** The `Low-pass gate` tag on `LadderLPF` is a mislabel; that module is a plain resonant ladder filter.

## Why fidelity here is measurable

Both circuits have peer-reviewed virtual-analog models validated against SPICE, so "the proper Buchla sound" becomes a testable claim.

**Timbre wavefolder** (Esqueda, Pöntynen, Välimäki, Parker, DAFx-17): five **non-identical folding cells in parallel** with a direct path, summed with alternating polarity. This differs fundamentally from Serge and Intellijel folders, which cascade in series, and is the main reason the 259 has its character. The repo's existing `InfiniteFolder` (`sin(x*drive*pi)`, one line) is not a substitute. All 25 coefficients and the full component table are in the dossier.

**Lowpass gate** (Parker and D'Angelo, DAFx-13): two-pole network with three switchable modes, plus a VTL5C3/2 vactrol model whose time constant switches on the sign of the input derivative, roughly **12 ms rising against 250 ms falling**. That ~20:1 asymmetry is where the plucked, struck-object character comes from, and it is the reason a VCA cannot substitute.

## Two findings that shape the design

**polyBLAMP only works because the folder is fed a sine.** The paper's antialiasing needs analytic threshold-crossing times, which it derives for sinusoidal input only. The 259 wires its folder to the principal oscillator's sine, so the assumption holds by construction. Keeping the internal path sinusoidal is therefore a design constraint, not an implementation detail. An [existing Faust port](https://github.com/georgezachos/b259wf) abandoned polyBLAMP and substituted filtering plus cubic distortion precisely because it accepts arbitrary input, and its README notes the method "is not sufficient for high frequencies and/or more complex signals". The spec routes external input down a fallback path so the internal path keeps the guarantee.

**The lowpass gate must use the topology-preserving discretisation.** The paper reports the direct form "appears to produce transients within the structure" and can "diverge to infinity" under modulation, while TPT is stable under any rate of modulation without oversampling. An LPG is modulated continuously, so this is a correctness requirement rather than a preference.

## Verification of the transcription

I evaluated the transcribed piecewise transfer function over a 10V sweep. It is **exactly odd-symmetric, max |f(x) + f(-x)| = 0.00e+00**, matching the paper's statement that folding introduces odd harmonics only. The output zigzag also matches Figure 4(a). That is an independent check that all 25 coefficients were transcribed correctly.

## Contents

- `specs/TheLantern.md` follows `specs/_TEMPLATE.md` exactly (all 11 sections, verified programmatically). Every panel control from both hardware modules is enumerated, including the Symmetry and Harmonics controls that the DAFx-17 paper explicitly omits from its analysis.
- `docs/specs/buchla-259-292.md` is the research dossier: full equations, component tables, coefficient values, panel references and the validation strategy.

## Notes for review

- **Symmetry and Harmonics mappings are inferences, not transcriptions.** The paper omits both controls. The dossier labels them as such and gives the reasoning; they need validating by spectrum analysis during implementation.
- **1.2 V/oct.** The hardware tracks 1.2 V/octave, not 1 V/oct. The spec defaults to the VCV standard so it patches normally and passes `test_pitch_tracking`, with 1.2 V/oct as a context-menu option.
- **Trademark.** The shipping `plugin.json` entry must not say "Buchla"; `scripts/verify_manifest.py` flags it. The hardware name stays in `specs/` and `docs/specs/`, where `_TEMPLATE.md` itself already uses "Inspired by Buchla Easel" as an example.
- **Papers are linked, not committed.** They are copyrighted conference publications. Equations and component values are reproduced with attribution so the implementation is self-contained. I departed from the approved plan here, which said to commit the PDFs.
- **Module name `TheLantern`** is a proposal, not settled. A vactrol is an LED and a light-dependent resistor, so the gate is literally light-controlled, and it fits the repo's `The___` naming. Easy to rename before implementation.

`just verify-manifest` still passes at 44/44; no module is registered by this PR.