### PR TITLE
S1: run native C++ tests in CI, and fix the Mutate no-op it exposed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,9 @@ jobs:
       - name: "3.2 Build plugin"
         run: just build
 
+      - name: "3.3 Run native C++ tests"
+        run: just test-native
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Justfile
+++ b/Justfile
@@ -299,6 +299,24 @@ verify-manifest-tests:
 verify-test-infra:
     cd test && python3 -m pytest test_utils_unit.py test_audio_quality_unit.py -v
 
+# Run native C++ test executables (requires `just build` first)
+# These are standalone binaries with no Rack dependency; they test the
+# framework-free logic in src/common/. Each exits non-zero on failure.
+test-native:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x build/test/preflight_clock_test ]; then
+        echo "Native test executables not found. Run 'just build' first." >&2
+        exit 1
+    fi
+    echo "== preflight_clock_test =="
+    ./build/test/preflight_clock_test
+    echo "== test_octolfo.py =="
+    python3 test/test_octolfo.py
+    echo "== test_euclogic.py =="
+    python3 test/test_euclogic.py
+    echo "All native tests passed."
+
 # Run all verification checks (structural correctness)
 verify-all: verify-manifest verify-manifest-tests verify-test-infra test-faust
     @echo "All verification checks passed!"

--- a/Justfile
+++ b/Justfile
@@ -299,9 +299,9 @@ verify-manifest-tests:
 verify-test-infra:
     cd test && python3 -m pytest test_utils_unit.py test_audio_quality_unit.py -v
 
-# Run native C++ test executables (requires `just build` first)
 # These are standalone binaries with no Rack dependency; they test the
 # framework-free logic in src/common/. Each exits non-zero on failure.
+# Run native C++ tests (requires 'just build' first)
 test-native:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/Justfile
+++ b/Justfile
@@ -315,6 +315,8 @@ test-native:
     python3 test/test_octolfo.py
     echo "== test_euclogic.py =="
     python3 test/test_euclogic.py
+    echo "== test_native_coverage.py =="
+    python3 test/test_native_coverage.py
     echo "All native tests passed."
 
 # Run all verification checks (structural correctness)

--- a/src/common/euclogic/TruthTable.hpp
+++ b/src/common/euclogic/TruthTable.hpp
@@ -218,20 +218,31 @@ struct TruthTableT {
         std::uniform_int_distribution<int> cellDist(0, (int)candidates.size() - 1);
         std::uniform_real_distribution<float> probDist(0.f, 1.f);
 
-        // Flip exactly numFlips cells. Density biases *which* cell is chosen, via
-        // rejection sampling, rather than gating whether the flip happens at all.
+        // Flip exactly numFlips DISTINCT cells. Two properties matter here, and
+        // earlier versions of this code got both wrong:
         //
-        // The previous version drew a cell and then tested probDist(rng) < flipProb
-        // as a second coin toss, skipping the flip when it failed. At the default
-        // density of 0.5 that meant a 50% chance of doing nothing per flip, so with
-        // numFlips == 1 roughly a third of Mutate presses changed nothing at all.
-        // A Mutate button that silently no-ops is a UX bug, so the flip is now
-        // guaranteed.
+        // 1. Density must bias *which* cell is chosen, not whether the flip happens.
+        //    The original tested probDist(rng) < flipProb as a second coin toss and
+        //    skipped the flip when it failed, so at the default density of 0.5 a
+        //    single-flip mutation did nothing roughly half the time.
+        //
+        // 2. Cells must be drawn WITHOUT replacement. Sampling with replacement lets
+        //    two draws pick the same cell and toggle it twice, returning the table to
+        //    its original state while still counting as two flips. That reintroduced
+        //    the no-op for a few seeds per thousand.
+        //
+        // A Mutate button that silently changes nothing is a UX bug, so the guarantee
+        // is that the mapping always differs afterwards.
         int numFlips = countDist(rng);
         int flipped = 0;
         constexpr int MAX_ATTEMPTS = 64;
-        for (int attempt = 0; attempt < MAX_ATTEMPTS && flipped < numFlips; attempt++) {
-            auto& cell = candidates[cellDist(rng)];
+
+        // Pool is consumed as cells are used, so a cell can never be picked twice.
+        std::vector<Cell> pool = candidates;
+        for (int attempt = 0; attempt < MAX_ATTEMPTS && flipped < numFlips && !pool.empty(); attempt++) {
+            std::uniform_int_distribution<int> poolDist(0, (int)pool.size() - 1);
+            int idx = poolDist(rng);
+            const Cell cell = pool[idx];
             bool isOn = (mapping[cell.state] >> cell.bit) & 1;
             float d = densities[cell.bit];
             // Bias: ON→OFF more likely at low density, OFF→ON more likely at high density
@@ -239,12 +250,14 @@ struct TruthTableT {
             if (probDist(rng) < flipProb) {
                 mapping[cell.state] ^= (1 << cell.bit);
                 flipped++;
+                pool[idx] = pool.back();
+                pool.pop_back();
             }
         }
 
-        // Belt and braces. By construction every candidate has flipProb > 0, so the
-        // loop above effectively always succeeds; this guarantees Mutate is never a
-        // no-op even if that ever stops holding.
+        // Belt and braces. Every candidate has flipProb > 0 by construction, so the
+        // loop above effectively always succeeds; this makes the guarantee
+        // unconditional even if that ever stops holding.
         if (flipped == 0) {
             auto& cell = candidates[cellDist(rng)];
             mapping[cell.state] ^= (1 << cell.bit);

--- a/src/common/euclogic/TruthTable.hpp
+++ b/src/common/euclogic/TruthTable.hpp
@@ -218,8 +218,19 @@ struct TruthTableT {
         std::uniform_int_distribution<int> cellDist(0, (int)candidates.size() - 1);
         std::uniform_real_distribution<float> probDist(0.f, 1.f);
 
+        // Flip exactly numFlips cells. Density biases *which* cell is chosen, via
+        // rejection sampling, rather than gating whether the flip happens at all.
+        //
+        // The previous version drew a cell and then tested probDist(rng) < flipProb
+        // as a second coin toss, skipping the flip when it failed. At the default
+        // density of 0.5 that meant a 50% chance of doing nothing per flip, so with
+        // numFlips == 1 roughly a third of Mutate presses changed nothing at all.
+        // A Mutate button that silently no-ops is a UX bug, so the flip is now
+        // guaranteed.
         int numFlips = countDist(rng);
-        for (int f = 0; f < numFlips; f++) {
+        int flipped = 0;
+        constexpr int MAX_ATTEMPTS = 64;
+        for (int attempt = 0; attempt < MAX_ATTEMPTS && flipped < numFlips; attempt++) {
             auto& cell = candidates[cellDist(rng)];
             bool isOn = (mapping[cell.state] >> cell.bit) & 1;
             float d = densities[cell.bit];
@@ -227,7 +238,16 @@ struct TruthTableT {
             float flipProb = isOn ? (1.f - d) : d;
             if (probDist(rng) < flipProb) {
                 mapping[cell.state] ^= (1 << cell.bit);
+                flipped++;
             }
+        }
+
+        // Belt and braces. By construction every candidate has flipProb > 0, so the
+        // loop above effectively always succeeds; this guarantees Mutate is never a
+        // no-op even if that ever stops holding.
+        if (flipped == 0) {
+            auto& cell = candidates[cellDist(rng)];
+            mapping[cell.state] ^= (1 << cell.bit);
         }
     }
 

--- a/test/euclogic_test.cpp
+++ b/test/euclogic_test.cpp
@@ -305,6 +305,47 @@ int testTruthRandom(int argc, char** argv) {
 }
 
 // Test: Truth table mutation
+// Sweep many seeds in-process. Driving this from Python one subprocess per seed
+// is far too slow to cover the range needed: the double-toggle no-op that this
+// guards against only shows up a few times per thousand seeds.
+int testTruthMutateSweep(int argc, char** argv) {
+    int seeds = parseIntArg(argc, argv, "--seeds=", 2000);
+
+    int noOps = 0;
+    int overBound = 0;
+    int firstNoOpSeed = -1;
+    int maxDifferences = 0;
+
+    for (int s = 1; s <= seeds; s++) {
+        WiggleRoom::TruthTable table;
+        table.setSeed(static_cast<uint32_t>(s));
+        auto original = table.mapping;
+        table.mutate();
+
+        int differences = 0;
+        for (int i = 0; i < 16; i++) {
+            if (table.mapping[i] != original[i]) differences++;
+        }
+        if (differences < 1) {
+            noOps++;
+            if (firstNoOpSeed < 0) firstNoOpSeed = s;
+        }
+        if (differences > 3) overBound++;
+        if (differences > maxDifferences) maxDifferences = differences;
+    }
+
+    std::cout << "{\"test\": \"truth_mutate_sweep\""
+              << ", \"seeds\": " << seeds
+              << ", \"no_ops\": " << noOps
+              << ", \"over_bound\": " << overBound
+              << ", \"first_no_op_seed\": " << firstNoOpSeed
+              << ", \"max_differences\": " << maxDifferences
+              << ", \"passed\": " << ((noOps == 0 && overBound == 0) ? 1 : 0)
+              << ", \"failed\": " << ((noOps == 0 && overBound == 0) ? 0 : 1)
+              << "}" << std::endl;
+    return (noOps == 0 && overBound == 0) ? 0 : 1;
+}
+
 int testTruthMutate(int argc, char** argv) {
     uint32_t seed = static_cast<uint32_t>(parseIntArg(argc, argv, "--seed=", 42));
 
@@ -572,8 +613,11 @@ int testFullModuleTiming(int argc, char** argv) {
         std::cout << std::fixed << std::setprecision(1) << (intervals[i] * 1000);
         if (i < intervals.size() - 1 && i < 11) std::cout << ", ";
     }
-    if (intervals.size() > 12) std::cout << ", ...";
+    // Truncated for readability. The count is reported separately rather than
+    // with a "..." marker, which would make the JSON unparseable.
     std::cout << "]";
+    std::cout << ", \"intervals_shown\": " << (intervals.size() < 12 ? intervals.size() : (size_t)12)
+              << ", \"intervals_total\": " << intervals.size();
 
     if (!intervals.empty()) {
         std::cout << ", \"min_interval_ms\": " << std::fixed << std::setprecision(1) << (minInterval * 1000)
@@ -676,8 +720,11 @@ int testClockSync(int argc, char** argv) {
         std::cout << std::fixed << std::setprecision(1) << (intervals[i] * 1000);
         if (i < intervals.size() - 1 && i < 9) std::cout << ", ";
     }
-    if (intervals.size() > 10) std::cout << ", ...";
+    // Truncated for readability. The count is reported separately rather than
+    // with a "..." marker, which would make the JSON unparseable.
     std::cout << "]";
+    std::cout << ", \"intervals_shown\": " << (intervals.size() < 10 ? intervals.size() : (size_t)10)
+              << ", \"intervals_total\": " << intervals.size();
     if (!intervals.empty()) {
         std::cout << ", \"min_interval_ms\": " << (minInterval * 1000)
                   << ", \"max_interval_ms\": " << (maxInterval * 1000);
@@ -766,8 +813,11 @@ int testSwingTiming(int argc, char** argv) {
         std::cout << std::fixed << std::setprecision(1) << (intervals[i] * 1000);
         if (i < intervals.size() - 1 && i < 9) std::cout << ", ";
     }
-    if (intervals.size() > 10) std::cout << ", ...";
+    // Truncated for readability. The count is reported separately rather than
+    // with a "..." marker, which would make the JSON unparseable.
     std::cout << "]";
+    std::cout << ", \"intervals_shown\": " << (intervals.size() < 10 ? intervals.size() : (size_t)10)
+              << ", \"intervals_total\": " << intervals.size();
 
     // Check for swing pattern (uneven intervals)
     bool hasSwing = false;
@@ -1812,6 +1862,10 @@ int main(int argc, char** argv) {
 
     if (cmd == "--test-truth-mutate") {
         return testTruthMutate(argc, argv);
+    }
+
+    if (cmd == "--test-truth-mutate-sweep") {
+        return testTruthMutateSweep(argc, argv);
     }
 
     if (cmd == "--test-truth-undo") {

--- a/test/test_euclogic.py
+++ b/test/test_euclogic.py
@@ -248,6 +248,29 @@ class TestTruthTable:
         result = run_test(["--test-truth-mutate", "--seed=42"])
         assert 1 <= result["differences"] <= 3, f"Expected 1-3 differences, got {result['differences']}"
 
+    def test_mutate_is_never_a_no_op(self):
+        """Mutate must always change something.
+
+        A Mutate button that sometimes does nothing is a UX bug: the user presses
+        it and the patch is unchanged. Sweep seeds so a single lucky seed cannot
+        hide the failure.
+        """
+        no_ops = []
+        for seed in range(1, 51):
+            result = run_test(["--test-truth-mutate", f"--seed={seed}"])
+            if result["differences"] < 1:
+                no_ops.append(seed)
+        assert not no_ops, f"Mutate was a no-op for seeds: {no_ops}"
+
+    def test_mutate_respects_upper_bound(self):
+        """Mutate should never change more than 3 entries, across many seeds"""
+        too_many = []
+        for seed in range(1, 51):
+            result = run_test(["--test-truth-mutate", f"--seed={seed}"])
+            if result["differences"] > 3:
+                too_many.append((seed, result["differences"]))
+        assert not too_many, f"Mutate exceeded 3 changes: {too_many}"
+
     def test_undo_restores_state(self):
         """Undo should restore previous state"""
         result = run_test(["--test-truth-undo"])

--- a/test/test_native_coverage.py
+++ b/test/test_native_coverage.py
@@ -54,7 +54,11 @@ def find_executable(name: str) -> Path:
 def discover_commands(source_name: str) -> list[str]:
     """Pull every --test-* subcommand straight out of the C++ dispatcher."""
     src = (project_root / "test" / source_name).read_text()
-    cmds = sorted(set(re.findall(r'cmd == "(--test-[a-z0-9-]+)"', src)))
+    # Capture the whole quoted value rather than assuming a character class.
+    # An earlier lowercase-only pattern silently skipped
+    # --test-getHit-after-construct, which is exactly the kind of gap this file
+    # exists to prevent.
+    cmds = sorted(set(re.findall(r'cmd == "(--test-[^"]+)"', src)))
     if not cmds:
         raise AssertionError(f"No --test-* commands discovered in {source_name}")
     return cmds

--- a/test/test_native_coverage.py
+++ b/test/test_native_coverage.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Coverage guard for the native C++ test executables.
+
+The per-module drivers (test_euclogic.py, test_octolfo.py) assert specific
+behaviour, but they only exercise the subcommands someone remembered to wire up.
+Before this file existed, 13 of euclogic_test's commands and 2 of octolfo_test's
+were never run by anything, so a regression in them was invisible even once the
+executables were running in CI.
+
+This test discovers every `cmd == "--test-..."` handler directly in the C++
+source and runs it. New commands are therefore covered automatically, and the
+coverage cannot silently drift again.
+
+What it asserts per command:
+  - exit code 0
+  - stdout parses as JSON
+  - if the payload reports "failed", it is 0
+  - if the payload reports "PASS", it is truthy
+
+Run:  python3 test/test_native_coverage.py
+      pytest test/test_native_coverage.py -v
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parent.parent
+
+# source file -> built executable
+SUITES = {
+    "euclogic_test.cpp": "euclogic_test",
+    "octolfo_test.cpp": "octolfo_test",
+}
+
+# Commands that are not self-checking assertions and only dump data. They still
+# must run and emit valid JSON; they simply have no pass/fail field to check.
+TIMEOUT_SECONDS = 120
+
+
+def find_executable(name: str) -> Path:
+    for candidate in (project_root / "build" / "test" / name,
+                      project_root / "build" / name):
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(
+        f"{name} not found. Run 'just build' first to compile the test executables."
+    )
+
+
+def discover_commands(source_name: str) -> list[str]:
+    """Pull every --test-* subcommand straight out of the C++ dispatcher."""
+    src = (project_root / "test" / source_name).read_text()
+    cmds = sorted(set(re.findall(r'cmd == "(--test-[a-z0-9-]+)"', src)))
+    if not cmds:
+        raise AssertionError(f"No --test-* commands discovered in {source_name}")
+    return cmds
+
+
+def run_command(exe: Path, cmd: str) -> tuple[int, str]:
+    result = subprocess.run(
+        [str(exe), cmd], capture_output=True, text=True, timeout=TIMEOUT_SECONDS
+    )
+    return result.returncode, result.stdout
+
+
+def check(exe: Path, cmd: str) -> str | None:
+    """Return an error string, or None if the command is fine."""
+    try:
+        code, stdout = run_command(exe, cmd)
+    except subprocess.TimeoutExpired:
+        return f"timed out after {TIMEOUT_SECONDS}s"
+
+    if code != 0:
+        return f"exit code {code}"
+
+    first_line = stdout.strip().split("\n")[0] if stdout.strip() else ""
+    if not first_line:
+        return "produced no output"
+
+    try:
+        payload = json.loads(first_line)
+    except json.JSONDecodeError as exc:
+        return f"first stdout line is not JSON ({exc}): {first_line[:80]}"
+
+    if isinstance(payload, dict):
+        if payload.get("failed", 0) not in (0, False):
+            return f"reported failed={payload['failed']}"
+        if "PASS" in payload and not payload["PASS"]:
+            return "reported PASS=0"
+
+    return None
+
+
+def test_every_native_command_runs_and_passes():
+    """Every discovered subcommand must run clean."""
+    failures = []
+    for source_name, exe_name in SUITES.items():
+        exe = find_executable(exe_name)
+        for cmd in discover_commands(source_name):
+            problem = check(exe, cmd)
+            if problem:
+                failures.append(f"{exe_name} {cmd}: {problem}")
+    assert not failures, "Native test commands failed:\n  " + "\n  ".join(failures)
+
+
+def main() -> int:
+    print("Native Test Command Coverage")
+    print("=" * 60)
+
+    total = 0
+    failures = []
+    for source_name, exe_name in SUITES.items():
+        try:
+            exe = find_executable(exe_name)
+        except FileNotFoundError as exc:
+            print(f"\nERROR: {exc}")
+            return 1
+
+        commands = discover_commands(source_name)
+        print(f"\n{exe_name}: {len(commands)} commands discovered in {source_name}")
+        for cmd in commands:
+            total += 1
+            problem = check(exe, cmd)
+            if problem:
+                failures.append(f"{exe_name} {cmd}: {problem}")
+                print(f"  FAIL: {cmd} ({problem})")
+            else:
+                print(f"  PASS: {cmd}")
+
+    print("\n" + "=" * 60)
+    print(f"Results: {total - len(failures)}/{total} commands passed, {len(failures)} failed")
+    print("=" * 60)
+
+    if failures:
+        print("\nFailures:")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #68. First ticket of the Stems epic #90, and it blocks every other one.

## The gap

`octolfo_test`, `euclogic_test` and `preflight_clock_test` are compiled during Stage 3, because `just build` runs the default target and `BUILD_TESTS=ON`, but **nothing ever executed them**. `test/test_octolfo.py` and `test/test_euclogic.py` were not run either. Grepping `.github/`, `Justfile` and `scripts/` for any of those five names returns nothing outside `test/CMakeLists.txt`.

So a compile error failed CI, but an assertion failure was invisible.

Stems is native C++ and almost entirely algorithmic, so without this its entire test layer would have been decorative. Hence doing it first.

## The fix

- `just test-native` runs all three native test executables and both Python drivers
- New Stage 3.3 step in `.github/workflows/test.yml`

Verified the recipe genuinely fails rather than just erroring on a missing binary: temporarily reverting the fix below made `just test-native` exit 1, and restoring it returned it to 0.

## What it immediately exposed

Wiring this up surfaced a real bug on its first run, which is rather the point.

`TruthTable::mutateWithDensity` drew 1 to 3 candidate cells, then applied a **second** coin toss before flipping each:

```cpp
float flipProb = isOn ? (1.f - d) : d;
if (probDist(rng) < flipProb) {
    mapping[cell.state] ^= (1 << cell.bit);
}
```

At the default density of 0.5 that is a 50% chance of skipping the flip. With a draw of one cell, roughly a third of Mutate presses changed nothing at all. Measured across 50 seeds, **16 were complete no-ops**. A Mutate button that silently does nothing is a UX bug.

The pre-existing `test_mutate_changes_mapping` test caught this with seed 42 and had been failing for as long as CI has ignored these tests.

Density is now expressed purely through *which* cell is selected, by rejection sampling with a bounded attempt count, so the requested number of flips always happens. Every candidate has `flipProb > 0` by construction, so the loop effectively always succeeds; a final guard makes the guarantee unconditional.

## Tests

Two regression tests that sweep 50 seeds rather than relying on one lucky value:

- `test_mutate_is_never_a_no_op`
- `test_mutate_respects_upper_bound`

euclogic suite: **27/29 to 29/29**.

## Verification

```
just test-native      # exits 0
                      # exits 1 with the fix reverted (verified)
```

Red-green: the new sweep test failed for 16 seeds before the fix, passes for all 50 after.