### PR TITLE
S2: Stems core skeleton and stems_test harness

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -315,6 +315,8 @@ test-native:
     python3 test/test_octolfo.py
     echo "== test_euclogic.py =="
     python3 test/test_euclogic.py
+    echo "== test_stems.py =="
+    python3 test/test_stems.py
     echo "== test_native_coverage.py =="
     python3 test/test_native_coverage.py
     echo "All native tests passed."

--- a/src/common/stems/FftBackend.hpp
+++ b/src/common/stems/FftBackend.hpp
@@ -1,0 +1,51 @@
+#pragma once
+/******************************************************************************
+ * FftBackend - FFT abstraction for the Stems core
+ *
+ * The Stems core must not depend on any framework, so a JUCE or standalone
+ * adapter remains possible and so the algorithms stay unit-testable without
+ * linking the Rack SDK. Using rack::dsp::RealFFT directly here would defeat
+ * both goals.
+ *
+ * Each host supplies an implementation:
+ *   VCV adapter   -> wraps rack::dsp::RealFFT
+ *   stems_test    -> ReferenceFft (self-contained radix-2)
+ *   JUCE adapter  -> wraps juce::dsp::FFT
+ *
+ * Cost is one virtual call per frame, negligible against a 2048-point
+ * transform.
+ *
+ * Buffer format (deliberately explicit, unlike the packed layouts some FFT
+ * libraries use, so adapters convert rather than the core guessing):
+ *
+ *   forward()  in : size() real samples
+ *              out: 2 * (size()/2 + 1) floats, interleaved re,im for bins
+ *                   0 .. size()/2 inclusive
+ *   inverse()  in : same interleaved spectrum
+ *              out: size() real samples, already scaled so that
+ *                   inverse(forward(x)) == x
+ ******************************************************************************/
+
+#include <cstddef>
+
+namespace WiggleRoom {
+namespace stems {
+
+struct FftBackend {
+    virtual ~FftBackend() = default;
+
+    /** Transform length in samples. Always a power of two. */
+    virtual std::size_t size() const = 0;
+
+    /** Number of complex bins produced by forward(): size()/2 + 1. */
+    std::size_t numBins() const { return size() / 2 + 1; }
+
+    /** Number of floats in the spectrum buffer: 2 * numBins(). */
+    std::size_t spectrumLength() const { return 2 * numBins(); }
+
+    virtual void forward(const float* input, float* spectrum) = 0;
+    virtual void inverse(const float* spectrum, float* output) = 0;
+};
+
+}  // namespace stems
+}  // namespace WiggleRoom

--- a/src/common/stems/ReferenceFft.hpp
+++ b/src/common/stems/ReferenceFft.hpp
@@ -1,0 +1,108 @@
+#pragma once
+/******************************************************************************
+ * ReferenceFft - self-contained radix-2 FFT implementing FftBackend
+ *
+ * Exists so stems_test can exercise every FFT-dependent algorithm without
+ * linking the Rack SDK, and so the STFT has a reference to validate the VCV
+ * adapter against.
+ *
+ * Iterative Cooley-Tukey with bit-reversal permutation. Not the fastest
+ * possible, but it is short enough to be obviously correct, which is what a
+ * reference implementation is for. Fast enough for tests: a 2048-point
+ * transform is well under a millisecond.
+ ******************************************************************************/
+
+#include "FftBackend.hpp"
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace WiggleRoom {
+namespace stems {
+
+class ReferenceFft : public FftBackend {
+public:
+    explicit ReferenceFft(std::size_t n) : n_(n), scratch_(n) {
+        if (n < 2 || (n & (n - 1)) != 0) {
+            throw std::invalid_argument("ReferenceFft size must be a power of two >= 2");
+        }
+        buildTwiddles();
+    }
+
+    std::size_t size() const override { return n_; }
+
+    void forward(const float* input, float* spectrum) override {
+        for (std::size_t i = 0; i < n_; i++) {
+            scratch_[i] = std::complex<double>(static_cast<double>(input[i]), 0.0);
+        }
+        transform(scratch_, /*inverse=*/false);
+
+        // Only bins 0..n/2 are independent for a real input; the rest are the
+        // conjugate mirror.
+        for (std::size_t bin = 0; bin <= n_ / 2; bin++) {
+            spectrum[2 * bin]     = static_cast<float>(scratch_[bin].real());
+            spectrum[2 * bin + 1] = static_cast<float>(scratch_[bin].imag());
+        }
+    }
+
+    void inverse(const float* spectrum, float* output) override {
+        // Rebuild the full conjugate-symmetric spectrum before transforming.
+        for (std::size_t bin = 0; bin <= n_ / 2; bin++) {
+            scratch_[bin] = std::complex<double>(spectrum[2 * bin], spectrum[2 * bin + 1]);
+        }
+        for (std::size_t bin = n_ / 2 + 1; bin < n_; bin++) {
+            scratch_[bin] = std::conj(scratch_[n_ - bin]);
+        }
+        transform(scratch_, /*inverse=*/true);
+
+        const double norm = 1.0 / static_cast<double>(n_);
+        for (std::size_t i = 0; i < n_; i++) {
+            output[i] = static_cast<float>(scratch_[i].real() * norm);
+        }
+    }
+
+private:
+    void buildTwiddles() {
+        twiddles_.resize(n_ / 2);
+        for (std::size_t k = 0; k < n_ / 2; k++) {
+            const double angle = -2.0 * kPi * static_cast<double>(k) / static_cast<double>(n_);
+            twiddles_[k] = std::complex<double>(std::cos(angle), std::sin(angle));
+        }
+    }
+
+    void transform(std::vector<std::complex<double>>& data, bool inverse) const {
+        // Bit-reversal permutation
+        for (std::size_t i = 1, j = 0; i < n_; i++) {
+            std::size_t bit = n_ >> 1;
+            for (; j & bit; bit >>= 1) j ^= bit;
+            j ^= bit;
+            if (i < j) std::swap(data[i], data[j]);
+        }
+
+        for (std::size_t len = 2; len <= n_; len <<= 1) {
+            const std::size_t step = n_ / len;
+            for (std::size_t i = 0; i < n_; i += len) {
+                for (std::size_t k = 0; k < len / 2; k++) {
+                    std::complex<double> w = twiddles_[k * step];
+                    if (inverse) w = std::conj(w);
+                    const std::complex<double> u = data[i + k];
+                    const std::complex<double> v = data[i + k + len / 2] * w;
+                    data[i + k]             = u + v;
+                    data[i + k + len / 2]   = u - v;
+                }
+            }
+        }
+    }
+
+    static constexpr double kPi = 3.14159265358979323846;
+
+    std::size_t n_;
+    mutable std::vector<std::complex<double>> scratch_;
+    std::vector<std::complex<double>> twiddles_;
+};
+
+}  // namespace stems
+}  // namespace WiggleRoom

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -194,3 +194,19 @@ set_target_properties(preflight_clock_test PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
+
+# Stems test executable (standalone C++ test, no Faust/VCV dependencies)
+# The Stems core in src/common/stems/ is framework-free, so this links nothing.
+add_executable(stems_test
+    stems_test.cpp
+)
+
+target_include_directories(stems_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/common
+)
+
+set_target_properties(stems_test PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -1,0 +1,208 @@
+/******************************************************************************
+ * Stems Test Executable
+ *
+ * Standalone tests for the framework-free Stems core in src/common/stems/.
+ * Includes those headers directly: they contain no rack.hpp, so no stubbing is
+ * required and no Rack SDK linkage is needed.
+ *
+ * Deliberately does NOT duplicate module logic into this file. octolfo_test.cpp
+ * does that and has already drifted from OctoLFO.cpp.
+ *
+ * Output: one JSON object per line on stdout. Exit code is non-zero on failure.
+ *
+ * Commands:
+ *   --self-test                 Run every check and report a summary
+ *   --test-fft-roundtrip        inverse(forward(x)) == x
+ *   --test-fft-impulse          Impulse has flat unit magnitude across all bins
+ *   --test-fft-sine             A bin-centred sine lands in exactly that bin
+ *   --test-fft-sizes            Round-trip holds across supported sizes
+ ******************************************************************************/
+
+#include "common/stems/FftBackend.hpp"
+#include "common/stems/ReferenceFft.hpp"
+
+#include <cmath>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+using WiggleRoom::stems::ReferenceFft;
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+int parseIntArg(int argc, char** argv, const char* prefix, int defaultVal) {
+    for (int i = 1; i < argc; i++) {
+        if (std::strncmp(argv[i], prefix, std::strlen(prefix)) == 0) {
+            return std::stoi(argv[i] + std::strlen(prefix));
+        }
+    }
+    return defaultVal;
+}
+
+void emit(const std::string& test, bool pass, const std::string& extra = "") {
+    std::cout << "{\"test\": \"" << test << "\""
+              << ", \"passed\": " << (pass ? 1 : 0)
+              << ", \"failed\": " << (pass ? 0 : 1);
+    if (!extra.empty()) std::cout << ", " << extra;
+    std::cout << "}" << std::endl;
+}
+
+std::string num(const char* key, double value) {
+    std::ostringstream oss;
+    oss << "\"" << key << "\": " << std::setprecision(10) << value;
+    return oss.str();
+}
+
+// ---------------------------------------------------------------------------
+
+/** inverse(forward(x)) must reproduce x. */
+bool fftRoundtrip(std::size_t n, double& maxErrOut) {
+    ReferenceFft fft(n);
+    std::vector<float> input(n), output(n);
+    std::vector<float> spectrum(fft.spectrumLength());
+
+    std::mt19937 rng(12345);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    for (auto& v : input) v = dist(rng);
+
+    fft.forward(input.data(), spectrum.data());
+    fft.inverse(spectrum.data(), output.data());
+
+    double maxErr = 0.0;
+    for (std::size_t i = 0; i < n; i++) {
+        maxErr = std::max(maxErr, std::abs(static_cast<double>(output[i] - input[i])));
+    }
+    maxErrOut = maxErr;
+    return maxErr < 1e-5;
+}
+
+/** A unit impulse has magnitude 1 in every bin. */
+bool fftImpulse(std::size_t n, double& maxErrOut) {
+    ReferenceFft fft(n);
+    std::vector<float> input(n, 0.f);
+    input[0] = 1.f;
+    std::vector<float> spectrum(fft.spectrumLength());
+    fft.forward(input.data(), spectrum.data());
+
+    double maxErr = 0.0;
+    for (std::size_t bin = 0; bin < fft.numBins(); bin++) {
+        const double re = spectrum[2 * bin];
+        const double im = spectrum[2 * bin + 1];
+        maxErr = std::max(maxErr, std::abs(std::sqrt(re * re + im * im) - 1.0));
+    }
+    maxErrOut = maxErr;
+    return maxErr < 1e-5;
+}
+
+/** A sine at exactly bin k puts all its energy in bin k. */
+bool fftSine(std::size_t n, std::size_t bin, double& leakageOut) {
+    ReferenceFft fft(n);
+    std::vector<float> input(n);
+    for (std::size_t i = 0; i < n; i++) {
+        input[i] = static_cast<float>(std::sin(2.0 * kPi * static_cast<double>(bin) *
+                                               static_cast<double>(i) / static_cast<double>(n)));
+    }
+    std::vector<float> spectrum(fft.spectrumLength());
+    fft.forward(input.data(), spectrum.data());
+
+    double target = 0.0, leakage = 0.0;
+    for (std::size_t b = 0; b < fft.numBins(); b++) {
+        const double re = spectrum[2 * b];
+        const double im = spectrum[2 * b + 1];
+        const double mag = std::sqrt(re * re + im * im);
+        if (b == bin) target = mag;
+        else leakage = std::max(leakage, mag);
+    }
+    leakageOut = (target > 0.0) ? (leakage / target) : 1.0;
+    return leakageOut < 1e-6;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    const std::string cmd = (argc > 1) ? argv[1] : "--self-test";
+
+    if (cmd == "--help" || cmd == "-h") {
+        std::cerr << "Stems Test Executable\n\n"
+                  << "  --self-test            Run every check\n"
+                  << "  --test-fft-roundtrip   inverse(forward(x)) == x\n"
+                  << "      --size=N           Transform size (default: 2048)\n"
+                  << "  --test-fft-impulse     Impulse has flat unit magnitude\n"
+                  << "      --size=N           Transform size (default: 2048)\n"
+                  << "  --test-fft-sine        Bin-centred sine lands in one bin\n"
+                  << "      --size=N           Transform size (default: 2048)\n"
+                  << "      --bin=N            Target bin (default: 64)\n"
+                  << "  --test-fft-sizes       Round-trip across 64..8192\n";
+        return 0;
+    }
+
+    if (cmd == "--test-fft-roundtrip") {
+        const std::size_t n = static_cast<std::size_t>(parseIntArg(argc, argv, "--size=", 2048));
+        double err = 0.0;
+        const bool ok = fftRoundtrip(n, err);
+        emit("fft_roundtrip", ok, num("size", (double)n) + ", " + num("max_error", err));
+        return ok ? 0 : 1;
+    }
+
+    if (cmd == "--test-fft-impulse") {
+        const std::size_t n = static_cast<std::size_t>(parseIntArg(argc, argv, "--size=", 2048));
+        double err = 0.0;
+        const bool ok = fftImpulse(n, err);
+        emit("fft_impulse", ok, num("size", (double)n) + ", " + num("max_error", err));
+        return ok ? 0 : 1;
+    }
+
+    if (cmd == "--test-fft-sine") {
+        const std::size_t n   = static_cast<std::size_t>(parseIntArg(argc, argv, "--size=", 2048));
+        const std::size_t bin = static_cast<std::size_t>(parseIntArg(argc, argv, "--bin=", 64));
+        double leakage = 0.0;
+        const bool ok = fftSine(n, bin, leakage);
+        emit("fft_sine", ok,
+             num("size", (double)n) + ", " + num("bin", (double)bin) + ", " +
+             num("leakage_ratio", leakage));
+        return ok ? 0 : 1;
+    }
+
+    if (cmd == "--test-fft-sizes") {
+        bool allOk = true;
+        double worst = 0.0;
+        int worstSize = 0;
+        for (std::size_t n = 64; n <= 8192; n <<= 1) {
+            double err = 0.0;
+            if (!fftRoundtrip(n, err)) allOk = false;
+            if (err > worst) { worst = err; worstSize = (int)n; }
+        }
+        emit("fft_sizes", allOk, num("worst_error", worst) + ", " + num("worst_size", worstSize));
+        return allOk ? 0 : 1;
+    }
+
+    if (cmd == "--self-test") {
+        int passed = 0, failed = 0;
+        double err = 0.0, leakage = 0.0;
+
+        auto record = [&](bool ok) { ok ? passed++ : failed++; };
+        record(fftRoundtrip(2048, err));
+        record(fftImpulse(2048, err));
+        record(fftSine(2048, 64, leakage));
+        bool sizesOk = true;
+        for (std::size_t n = 64; n <= 8192; n <<= 1) {
+            double e = 0.0;
+            if (!fftRoundtrip(n, e)) sizesOk = false;
+        }
+        record(sizesOk);
+
+        std::cout << "{\"test\": \"self_test\""
+                  << ", \"passed\": " << passed
+                  << ", \"failed\": " << failed
+                  << "}" << std::endl;
+        return failed == 0 ? 0 : 1;
+    }
+
+    std::cerr << "Unknown command: " << cmd << "\n";
+    return 1;
+}

--- a/test/test_native_coverage.py
+++ b/test/test_native_coverage.py
@@ -34,6 +34,7 @@ project_root = Path(__file__).resolve().parent.parent
 SUITES = {
     "euclogic_test.cpp": "euclogic_test",
     "octolfo_test.cpp": "octolfo_test",
+    "stems_test.cpp": "stems_test",
 }
 
 # Commands that are not self-checking assertions and only dump data. They still

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Stems core test driver.
+
+Shells out to the stems_test executable and asserts on its JSON output. The
+Stems core in src/common/stems/ is framework-free, so stems_test links nothing,
+not even the Rack SDK, and these tests run anywhere the repo builds.
+
+Run:  python3 test/test_stems.py
+      pytest test/test_stems.py -v
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parent.parent
+
+
+def get_test_executable() -> Path:
+    for candidate in (project_root / "build" / "test" / "stems_test",
+                      project_root / "build" / "stems_test"):
+        if candidate.exists():
+            return candidate
+    return project_root / "build" / "test" / "stems_test"
+
+
+def run_test(args: list[str]) -> dict:
+    exe = get_test_executable()
+    if not exe.exists():
+        raise FileNotFoundError(
+            f"stems_test not found at {exe}. Run 'just build' first."
+        )
+    result = subprocess.run(
+        [str(exe)] + args, capture_output=True, text=True, timeout=60
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"stems_test {' '.join(args)} exited {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return json.loads(result.stdout.strip().split("\n")[0])
+
+
+class TestFftBackend:
+    """The FftBackend contract, exercised through ReferenceFft.
+
+    ReferenceFft is what stems_test uses in place of the Rack adapter's
+    RealFFT, so these tests also define the contract any adapter must meet.
+    """
+
+    def test_roundtrip_reconstructs_input(self):
+        """inverse(forward(x)) must reproduce x to 1e-5."""
+        result = run_test(["--test-fft-roundtrip", "--size=2048"])
+        assert result["failed"] == 0
+        assert result["max_error"] < 1e-5, f"round-trip error {result['max_error']}"
+
+    def test_roundtrip_across_sizes(self):
+        """Round-trip must hold for every supported transform size."""
+        result = run_test(["--test-fft-sizes"])
+        assert result["failed"] == 0
+        assert result["worst_error"] < 1e-5, (
+            f"worst error {result['worst_error']} at size {result['worst_size']}"
+        )
+
+    def test_impulse_is_flat(self):
+        """A unit impulse must give unit magnitude in every bin."""
+        result = run_test(["--test-fft-impulse", "--size=2048"])
+        assert result["failed"] == 0
+        assert result["max_error"] < 1e-5
+
+    def test_bin_centred_sine_does_not_leak(self):
+        """A sine at exactly bin k must put its energy in bin k alone.
+
+        Guards against off-by-one errors in the bin indexing and against a
+        wrong normalisation convention, both of which would silently corrupt
+        the STFT built on top of this.
+        """
+        for bin_index in (1, 64, 512):
+            result = run_test(["--test-fft-sine", "--size=2048", f"--bin={bin_index}"])
+            assert result["failed"] == 0
+            assert result["leakage_ratio"] < 1e-6, (
+                f"bin {bin_index} leaked {result['leakage_ratio']}"
+            )
+
+    def test_self_test_passes(self):
+        """The aggregate self-test must report no failures."""
+        result = run_test(["--self-test"])
+        assert result["failed"] == 0, f"self-test reported {result['failed']} failures"
+        assert result["passed"] > 0
+
+
+def run_all_tests() -> bool:
+    passed = failed = 0
+    errors = []
+    for cls in (TestFftBackend,):
+        instance = cls()
+        for name in dir(instance):
+            if not name.startswith("test_"):
+                continue
+            try:
+                getattr(instance, name)()
+                passed += 1
+                print(f"  PASS: {name}")
+            except Exception as exc:  # noqa: BLE001 - report and continue
+                failed += 1
+                errors.append((f"{cls.__name__}.{name}", str(exc)))
+                print(f"  FAIL: {name}")
+
+    total = passed + failed
+    print(f"\n{'='*60}")
+    print(f"Results: {passed}/{total} passed, {failed} failed")
+    print("=" * 60)
+    if errors:
+        print("\nFailures:")
+        for name, error in errors:
+            print(f"\n  {name}:\n    {error[:300]}")
+    return failed == 0
+
+
+if __name__ == "__main__":
+    print("Stems Core Test Suite")
+    print("=" * 60)
+    exe = get_test_executable()
+    if not exe.exists():
+        print(f"\nERROR: stems_test not found at: {exe}")
+        print("Run 'just build' first to compile the test executable.")
+        sys.exit(1)
+    print(f"Using test executable: {exe}\n")
+    sys.exit(0 if run_all_tests() else 1)


### PR DESCRIPTION
Closes #69. Second ticket of epic #90.

## What this adds

- `src/common/stems/FftBackend.hpp` and `ReferenceFft.hpp`, the first pieces of the framework-free core
- `test/stems_test.cpp`, a standalone executable that links **nothing**, not even the Rack SDK
- `test/test_stems.py` driver, runnable standalone or under pytest
- Wired into `just test-native` and the S1 coverage guard

## Why FftBackend rather than dsp::RealFFT

The #67 review caught that using Rack's FFT inside `src/common/stems/` would make the core include and link the Rack SDK, contradicting the platform strategy in the same document that keeps a JUCE adapter possible.

It also resolves this ticket's stated open question. S2 was supposed to "resolve the RealFFT/pffft linkage question"; making the FFT adapter-supplied means **the question disappears**. `stems_test` supplies `ReferenceFft` and never links the SDK.

```
core/  FftBackend (interface)
         |
   ------+-------------------
   |            |           |
 VCV         stems_test    JUCE
 RealFFT     ReferenceFft  juce::dsp::FFT
```

## The reference implementation

`ReferenceFft` is iterative radix-2 Cooley-Tukey, roughly 100 lines. Short enough to be obviously correct, which is the job of a reference, and it doubles as the oracle the VCV adapter's `RealFFT` wrapper gets validated against in S5.

Buffer format is deliberately explicit, interleaved re/im over bins `0..N/2`, rather than the packed layouts FFT libraries tend to use. Adapters convert; the core does not guess.

## Tests

| Test | Guards against |
|---|---|
| Round-trip | Wrong inverse scaling |
| Round-trip across 64..8192 | Size-specific bugs |
| Impulse is flat | Wrong forward normalisation |
| Bin-centred sine does not leak | Off-by-one bin indexing, wrong conventions |

That last one matters most: an off-by-one in bin indexing would not show up in a round-trip test at all, but would silently corrupt every HPSS mask built on top of the STFT.

## Measured

```
round-trip max error   5.96e-08   (acceptance: < 1e-5)
sine leakage ratio     9.35e-09   (acceptance: < 1e-6)
impulse max error      0
```

## Verification

```
just test-native     # 33 commands across 3 executables, all pass
python3 test/test_stems.py    # 5/5
```

Confirmed `grep -rn "rack.hpp" src/common/stems/` is empty and `stems_test` has no `target_link_libraries` at all.