### PR TITLE
S3: Stems capture ring buffer

### DIFF
--- a/src/common/stems/RingBuffer.hpp
+++ b/src/common/stems/RingBuffer.hpp
@@ -1,0 +1,156 @@
+#pragma once
+/******************************************************************************
+ * RingBuffer - the Stems audio capture buffer
+ *
+ * Framework-free: no rack.hpp, so it is directly unit-testable.
+ *
+ * Why not rack::dsp::RingBuffer: the SDK ring buffers are
+ * `template <typename T, size_t S>` with capacity fixed at compile time, so
+ * they cannot back a buffer whose length depends on sample rate. This one
+ * allocates once at construction, from the sample rate and the duration cap,
+ * and never reallocates.
+ *
+ * Real-time contract:
+ *   - write() and every read allocate nothing and take no locks
+ *   - capacity is fixed for the lifetime of the object
+ *   - resize() exists for sample-rate changes and is NOT audio-thread safe;
+ *     the caller must guarantee no concurrent access
+ *
+ * The 32 second cap from specs/Stems.md is enforced by the caller passing
+ * maxSeconds; at 96 kHz stereo that is roughly 24.6 MB.
+ ******************************************************************************/
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+namespace WiggleRoom {
+namespace stems {
+
+class RingBuffer {
+public:
+    /**
+     * @param sampleRate  Frames per second.
+     * @param maxSeconds  Duration cap. Capacity is sampleRate * maxSeconds.
+     * @param channels    1 (mono) or 2 (stereo). Stored interleaved.
+     */
+    RingBuffer(int sampleRate, float maxSeconds, int channels)
+        : channels_(channels < 2 ? 1 : 2) {
+        allocate(sampleRate, maxSeconds);
+    }
+
+    std::size_t capacityFrames() const { return capacityFrames_; }
+    int channels() const { return channels_; }
+
+    /** Total frames ever written, ignoring overwrites. */
+    std::size_t framesWritten() const { return framesWritten_; }
+
+    /** Frames currently retrievable, saturating at capacity. */
+    std::size_t framesStored() const {
+        return std::min(framesWritten_, capacityFrames_);
+    }
+
+    bool empty() const { return framesWritten_ == 0; }
+
+    /** Append one frame. Overwrites the oldest frame once full. */
+    void write(float left, float right) {
+        const std::size_t base = writeIndex_ * static_cast<std::size_t>(channels_);
+        data_[base] = left;
+        if (channels_ == 2) data_[base + 1] = right;
+
+        writeIndex_ = (writeIndex_ + 1) % capacityFrames_;
+        framesWritten_++;
+    }
+
+    /**
+     * Read a stored frame. Index 0 is the OLDEST surviving frame, so callers
+     * see a stable timeline regardless of how far the write head has wrapped.
+     * Out-of-range indices yield silence rather than reading garbage, which
+     * keeps the empty-buffer state safe.
+     */
+    void readFrame(std::size_t index, float& left, float& right) const {
+        const std::size_t stored = framesStored();
+        if (stored == 0 || index >= stored) {
+            left = right = 0.f;
+            return;
+        }
+        const std::size_t physical = (oldestIndex() + index) % capacityFrames_;
+        const std::size_t base = physical * static_cast<std::size_t>(channels_);
+        left  = data_[base];
+        right = (channels_ == 2) ? data_[base + 1] : data_[base];
+    }
+
+    /**
+     * Linearly interpolated read, for vari-speed (repitch) playback.
+     * Positions outside the stored range yield silence.
+     */
+    void readFrameInterpolated(double position, float& left, float& right) const {
+        const std::size_t stored = framesStored();
+        if (stored == 0 || position < 0.0) {
+            left = right = 0.f;
+            return;
+        }
+        const std::size_t i0 = static_cast<std::size_t>(position);
+        if (i0 >= stored) {
+            left = right = 0.f;
+            return;
+        }
+        const float frac = static_cast<float>(position - static_cast<double>(i0));
+
+        float l0 = 0.f, r0 = 0.f, l1 = 0.f, r1 = 0.f;
+        readFrame(i0, l0, r0);
+        // Hold the final frame rather than wrapping to the start, so a read at
+        // the very end does not splice in unrelated audio.
+        readFrame(std::min(i0 + 1, stored - 1), l1, r1);
+
+        left  = l0 + (l1 - l0) * frac;
+        right = r0 + (r1 - r0) * frac;
+    }
+
+    /** Discard contents. Keeps the allocation. */
+    void clear() {
+        std::fill(data_.begin(), data_.end(), 0.f);
+        writeIndex_ = 0;
+        framesWritten_ = 0;
+    }
+
+    /**
+     * Reallocate for a new sample rate. NOT audio-thread safe: the caller must
+     * ensure nothing is reading or writing. Contents are discarded, since
+     * resampling them is the caller's decision.
+     */
+    void resize(int sampleRate, float maxSeconds) {
+        allocate(sampleRate, maxSeconds);
+    }
+
+    /** Storage identity, used by tests to prove no reallocation occurred. */
+    const float* rawData() const { return data_.data(); }
+
+private:
+    void allocate(int sampleRate, float maxSeconds) {
+        if (sampleRate < 1) sampleRate = 1;
+        if (maxSeconds <= 0.f) maxSeconds = 1.f;
+        capacityFrames_ = static_cast<std::size_t>(
+            static_cast<double>(sampleRate) * static_cast<double>(maxSeconds));
+        if (capacityFrames_ < 1) capacityFrames_ = 1;
+
+        data_.assign(capacityFrames_ * static_cast<std::size_t>(channels_), 0.f);
+        writeIndex_ = 0;
+        framesWritten_ = 0;
+    }
+
+    /** Physical index of the oldest surviving frame. */
+    std::size_t oldestIndex() const {
+        if (framesWritten_ < capacityFrames_) return 0;
+        return writeIndex_;  // write head sits on the oldest frame once wrapped
+    }
+
+    int channels_;
+    std::size_t capacityFrames_ = 0;
+    std::size_t writeIndex_ = 0;
+    std::size_t framesWritten_ = 0;
+    std::vector<float> data_;
+};
+
+}  // namespace stems
+}  // namespace WiggleRoom

--- a/src/common/stems/RingBuffer.hpp
+++ b/src/common/stems/RingBuffer.hpp
@@ -86,15 +86,19 @@ public:
      */
     void readFrameInterpolated(double position, float& left, float& right) const {
         const std::size_t stored = framesStored();
-        if (stored == 0 || position < 0.0) {
+
+        // Validate fully while the value is still floating point, BEFORE any
+        // cast. Converting inf or NaN to size_t is undefined behaviour, and NaN
+        // slips past a bare `position < 0.0` guard because every comparison
+        // with NaN is false. Unchecked, an infinite or NaN playback position
+        // emits NaN audio, which then poisons everything downstream of it.
+        if (stored == 0 || !std::isfinite(position) || position < 0.0 ||
+            position >= static_cast<double>(stored)) {
             left = right = 0.f;
             return;
         }
+
         const std::size_t i0 = static_cast<std::size_t>(position);
-        if (i0 >= stored) {
-            left = right = 0.f;
-            return;
-        }
         const float frac = static_cast<float>(position - static_cast<double>(i0));
 
         float l0 = 0.f, r0 = 0.f, l1 = 0.f, r1 = 0.f;
@@ -107,9 +111,16 @@ public:
         right = r0 + (r1 - r0) * frac;
     }
 
-    /** Discard contents. Keeps the allocation. */
+    /**
+     * Discard contents. O(1) and safe to call from the audio thread.
+     *
+     * Deliberately does NOT zero the storage. That would be up to 24.6 MB at
+     * 96 kHz stereo over the 32 second cap, written synchronously at the exact
+     * moment a new take starts, which is long enough to cause a dropout.
+     * Resetting the counters already makes every old sample unreachable:
+     * framesStored() becomes 0 and every read returns silence.
+     */
     void clear() {
-        std::fill(data_.begin(), data_.end(), 0.f);
         writeIndex_ = 0;
         framesWritten_ = 0;
     }

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -21,6 +21,8 @@
  *   --test-buffer-no-alloc      No allocation after construction
  *   --test-buffer-interpolate   Fractional reads interpolate correctly
  *   --test-buffer-capacity      Capacity honours the duration cap
+ *   --test-buffer-non-finite    inf/NaN positions give silence, not NaN audio
+ *   --test-buffer-clear-cheap   clear() is O(1) and does not touch storage
  ******************************************************************************/
 
 #include "common/stems/FftBackend.hpp"
@@ -31,6 +33,7 @@
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <random>
 #include <string>
 #include <vector>
@@ -229,6 +232,72 @@ bool bufferCapacity(std::string& detail) {
     return true;
 }
 
+/**
+ * Non-finite positions must yield silence, not undefined behaviour.
+ *
+ * static_cast<size_t> of inf or NaN is UB, and NaN slips past a plain
+ * `position < 0.0` guard because every comparison with NaN is false. Left
+ * unchecked this emits NaN audio, which then propagates through the whole
+ * graph.
+ */
+bool bufferNonFinite(std::string& detail) {
+    RingBuffer buf(48000, 1.0f, 2);
+    for (std::size_t i = 0; i < 100; i++) buf.write(1.f, 1.f);
+
+    const double inf = std::numeric_limits<double>::infinity();
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double cases[] = {inf, -inf, nan, -1.0, 1e30, 100.0, 1000.0};
+
+    for (double pos : cases) {
+        float l = -1.f, r = -1.f;
+        buf.readFrameInterpolated(pos, l, r);
+        if (std::isnan(l) || std::isnan(r)) {
+            detail = "position produced NaN audio";
+            return false;
+        }
+        if (!(l == 0.f && r == 0.f)) {
+            detail = "out-of-range position did not give silence, got " +
+                     std::to_string(l) + "," + std::to_string(r);
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * clear() must not touch the storage.
+ *
+ * Filling the whole allocation is up to 24.6 MB at 96 kHz stereo over the
+ * 32 second cap. Doing that synchronously when a new take starts would stall
+ * the audio thread exactly when recording begins. Resetting the counters
+ * already makes every old sample unreachable, so the fill buys nothing.
+ *
+ * Verified by observing that old samples remain physically present in storage
+ * while being unreachable through the public API.
+ */
+bool bufferClearIsCheap(std::string& detail) {
+    RingBuffer buf(48000, 1.0f, 1);
+    for (std::size_t i = 0; i < 500; i++) buf.write(0.75f, 0.f);
+
+    const float sentinel = buf.rawData()[0];
+    if (sentinel != 0.75f) { detail = "setup failed, storage not written"; return false; }
+
+    buf.clear();
+
+    if (buf.framesStored() != 0)  { detail = "framesStored not reset"; return false; }
+    if (buf.framesWritten() != 0) { detail = "framesWritten not reset"; return false; }
+
+    float l = -1.f, r = -1.f;
+    buf.readFrame(0, l, r);
+    if (l != 0.f || r != 0.f) { detail = "cleared buffer did not read as silence"; return false; }
+
+    if (buf.rawData()[0] != sentinel) {
+        detail = "clear() wrote to storage; it should only reset counters";
+        return false;
+    }
+    return true;
+}
+
 }  // namespace
 
 /**
@@ -250,6 +319,8 @@ const char* const kCommands[] = {
     "--test-buffer-no-alloc",
     "--test-buffer-interpolate",
     "--test-buffer-capacity",
+    "--test-buffer-non-finite",
+    "--test-buffer-clear-cheap",
 };
 
 int main(int argc, char** argv) {
@@ -323,6 +394,8 @@ int main(int argc, char** argv) {
             {"--test-buffer-no-alloc",    "buffer_no_alloc",    bufferNoAlloc},
             {"--test-buffer-interpolate", "buffer_interpolate", bufferInterpolate},
             {"--test-buffer-capacity",    "buffer_capacity",    bufferCapacity},
+            {"--test-buffer-non-finite",  "buffer_non_finite",  bufferNonFinite},
+            {"--test-buffer-clear-cheap", "buffer_clear_cheap", bufferClearIsCheap},
         };
         for (const auto& c : bufferCases) {
             if (cmd == c.cmd) {
@@ -354,6 +427,8 @@ int main(int argc, char** argv) {
         record(bufferNoAlloc(detail));
         record(bufferInterpolate(detail));
         record(bufferCapacity(detail));
+        record(bufferNonFinite(detail));
+        record(bufferClearIsCheap(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -16,10 +16,16 @@
  *   --test-fft-impulse          Impulse has flat unit magnitude across all bins
  *   --test-fft-sine             A bin-centred sine lands in exactly that bin
  *   --test-fft-sizes            Round-trip holds across supported sizes
+ *   --test-buffer-roundtrip     Written samples read back bit-exact
+ *   --test-buffer-wraparound    Writing past capacity overwrites oldest first
+ *   --test-buffer-no-alloc      No allocation after construction
+ *   --test-buffer-interpolate   Fractional reads interpolate correctly
+ *   --test-buffer-capacity      Capacity honours the duration cap
  ******************************************************************************/
 
 #include "common/stems/FftBackend.hpp"
 #include "common/stems/ReferenceFft.hpp"
+#include "common/stems/RingBuffer.hpp"
 
 #include <cmath>
 #include <cstring>
@@ -122,6 +128,107 @@ bool fftSine(std::size_t n, std::size_t bin, double& leakageOut) {
     return leakageOut < 1e-6;
 }
 
+// ---------------------------------------------------------------------------
+// RingBuffer
+// ---------------------------------------------------------------------------
+
+using WiggleRoom::stems::RingBuffer;
+
+/** Every written frame must read back bit-exact. */
+bool bufferRoundtrip(std::string& detail) {
+    RingBuffer buf(48000, /*maxSeconds=*/1.0f, /*channels=*/2);
+    const std::size_t n = 1000;
+    for (std::size_t i = 0; i < n; i++) {
+        buf.write(static_cast<float>(i) * 0.001f, static_cast<float>(i) * -0.001f);
+    }
+    if (buf.framesWritten() != n) { detail = "framesWritten mismatch"; return false; }
+
+    for (std::size_t i = 0; i < n; i++) {
+        float l = 0.f, r = 0.f;
+        buf.readFrame(i, l, r);
+        if (l != static_cast<float>(i) * 0.001f || r != static_cast<float>(i) * -0.001f) {
+            detail = "sample " + std::to_string(i) + " differs";
+            return false;
+        }
+    }
+    return true;
+}
+
+/** Writing past capacity must overwrite the oldest frames, not corrupt or grow. */
+bool bufferWraparound(std::string& detail) {
+    RingBuffer buf(1000, /*maxSeconds=*/1.0f, /*channels=*/1);  // capacity 1000
+    const std::size_t cap = buf.capacityFrames();
+    // Write 1.5x capacity. The last `cap` values must survive.
+    const std::size_t total = cap + cap / 2;
+    for (std::size_t i = 0; i < total; i++) buf.write(static_cast<float>(i), 0.f);
+
+    if (buf.framesStored() != cap) { detail = "framesStored should saturate at capacity"; return false; }
+
+    // readFrame(0) is the oldest surviving frame.
+    for (std::size_t i = 0; i < cap; i++) {
+        float l = 0.f, r = 0.f;
+        buf.readFrame(i, l, r);
+        const float expected = static_cast<float>(total - cap + i);
+        if (l != expected) {
+            detail = "wrapped frame " + std::to_string(i) + " expected " +
+                     std::to_string(expected) + " got " + std::to_string(l);
+            return false;
+        }
+    }
+    return true;
+}
+
+/** Capacity must be fixed at construction and never change. */
+bool bufferNoAlloc(std::string& detail) {
+    RingBuffer buf(48000, 2.0f, 2);
+    const std::size_t capBefore = buf.capacityFrames();
+    const void* dataBefore = buf.rawData();
+
+    for (std::size_t i = 0; i < capBefore * 3; i++) buf.write(0.5f, -0.5f);
+    buf.clear();
+    for (std::size_t i = 0; i < capBefore; i++) buf.write(0.25f, -0.25f);
+
+    if (buf.capacityFrames() != capBefore) { detail = "capacity changed"; return false; }
+    if (buf.rawData() != dataBefore) { detail = "storage was reallocated"; return false; }
+    return true;
+}
+
+/** Fractional reads must interpolate linearly between neighbouring frames. */
+bool bufferInterpolate(std::string& detail) {
+    RingBuffer buf(48000, 1.0f, 1);
+    for (std::size_t i = 0; i < 100; i++) buf.write(static_cast<float>(i), 0.f);
+
+    struct Case { double pos; float expect; };
+    const Case cases[] = {{0.0, 0.f}, {0.5, 0.5f}, {10.25, 10.25f}, {98.75, 98.75f}};
+    for (const auto& c : cases) {
+        float l = 0.f, r = 0.f;
+        buf.readFrameInterpolated(c.pos, l, r);
+        if (std::abs(l - c.expect) > 1e-4f) {
+            detail = "pos " + std::to_string(c.pos) + " expected " +
+                     std::to_string(c.expect) + " got " + std::to_string(l);
+            return false;
+        }
+    }
+    return true;
+}
+
+/** Capacity must follow sampleRate * maxSeconds, which is how the spec's
+    32 second cap is enforced. */
+bool bufferCapacity(std::string& detail) {
+    struct Case { int rate; float seconds; };
+    const Case cases[] = {{44100, 32.f}, {48000, 32.f}, {96000, 32.f}, {48000, 4.f}};
+    for (const auto& c : cases) {
+        RingBuffer buf(c.rate, c.seconds, 2);
+        const std::size_t expected = static_cast<std::size_t>(c.rate * c.seconds);
+        if (buf.capacityFrames() != expected) {
+            detail = "rate " + std::to_string(c.rate) + " expected " +
+                     std::to_string(expected) + " got " + std::to_string(buf.capacityFrames());
+            return false;
+        }
+    }
+    return true;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -181,9 +288,30 @@ int main(int argc, char** argv) {
         return allOk ? 0 : 1;
     }
 
+    // RingBuffer commands
+    {
+        struct BufferCase { const char* cmd; const char* name; bool (*fn)(std::string&); };
+        const BufferCase bufferCases[] = {
+            {"--test-buffer-roundtrip",   "buffer_roundtrip",   bufferRoundtrip},
+            {"--test-buffer-wraparound",  "buffer_wraparound",  bufferWraparound},
+            {"--test-buffer-no-alloc",    "buffer_no_alloc",    bufferNoAlloc},
+            {"--test-buffer-interpolate", "buffer_interpolate", bufferInterpolate},
+            {"--test-buffer-capacity",    "buffer_capacity",    bufferCapacity},
+        };
+        for (const auto& c : bufferCases) {
+            if (cmd == c.cmd) {
+                std::string detail;
+                const bool ok = c.fn(detail);
+                emit(c.name, ok, detail.empty() ? "" : ("\"detail\": \"" + detail + "\""));
+                return ok ? 0 : 1;
+            }
+        }
+    }
+
     if (cmd == "--self-test") {
         int passed = 0, failed = 0;
         double err = 0.0, leakage = 0.0;
+        std::string detail;
 
         auto record = [&](bool ok) { ok ? passed++ : failed++; };
         record(fftRoundtrip(2048, err));
@@ -195,6 +323,11 @@ int main(int argc, char** argv) {
             if (!fftRoundtrip(n, e)) sizesOk = false;
         }
         record(sizesOk);
+        record(bufferRoundtrip(detail));
+        record(bufferWraparound(detail));
+        record(bufferNoAlloc(detail));
+        record(bufferInterpolate(detail));
+        record(bufferCapacity(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -231,8 +231,34 @@ bool bufferCapacity(std::string& detail) {
 
 }  // namespace
 
+/**
+ * Every runnable subcommand, declared once.
+ *
+ * The coverage guard reads this via --list-commands rather than scraping the
+ * source with a regex. Scraping has already gone wrong twice: once on a
+ * lowercase-only character class that missed a mixed-case name, and once on
+ * table-driven dispatch that does not look like `cmd == "..."` at all. An
+ * executable declaring its own commands cannot drift from itself.
+ */
+const char* const kCommands[] = {
+    "--test-fft-roundtrip",
+    "--test-fft-impulse",
+    "--test-fft-sine",
+    "--test-fft-sizes",
+    "--test-buffer-roundtrip",
+    "--test-buffer-wraparound",
+    "--test-buffer-no-alloc",
+    "--test-buffer-interpolate",
+    "--test-buffer-capacity",
+};
+
 int main(int argc, char** argv) {
     const std::string cmd = (argc > 1) ? argv[1] : "--self-test";
+
+    if (cmd == "--list-commands") {
+        for (const char* c : kCommands) std::cout << c << "\n";
+        return 0;
+    }
 
     if (cmd == "--help" || cmd == "-h") {
         std::cerr << "Stems Test Executable\n\n"

--- a/test/test_native_coverage.py
+++ b/test/test_native_coverage.py
@@ -8,9 +8,14 @@ Before this file existed, 13 of euclogic_test's commands and 2 of octolfo_test's
 were never run by anything, so a regression in them was invisible even once the
 executables were running in CI.
 
-This test discovers every `cmd == "--test-..."` handler directly in the C++
-source and runs it. New commands are therefore covered automatically, and the
-coverage cannot silently drift again.
+This test discovers every runnable subcommand and runs it, so new commands are
+covered automatically and the coverage cannot silently drift.
+
+Discovery asks each executable via --list-commands, which is authoritative.
+Scraping the C++ source is only a fallback, because scraping has already been
+wrong twice: a lowercase-only character class missed
+--test-getHit-after-construct, and table-driven dispatch does not look like
+`cmd == "..."` at all, which hid five commands in stems_test.
 
 What it asserts per command:
   - exit code 0
@@ -52,13 +57,27 @@ def find_executable(name: str) -> Path:
     )
 
 
-def discover_commands(source_name: str) -> list[str]:
-    """Pull every --test-* subcommand straight out of the C++ dispatcher."""
+def discover_commands(source_name: str, exe: Path) -> list[str]:
+    """Discover every runnable --test-* subcommand.
+
+    Prefers asking the executable itself via --list-commands, which is
+    authoritative and cannot drift. Falls back to scraping the C++ dispatcher
+    for executables that do not implement it yet.
+
+    Scraping has already been wrong twice: a lowercase-only character class
+    silently skipped --test-getHit-after-construct, and table-driven dispatch
+    does not match `cmd == "..."` at all, which hid five commands in
+    stems_test. Hence the preference for asking.
+    """
+    listed = subprocess.run(
+        [str(exe), "--list-commands"], capture_output=True, text=True, timeout=30
+    )
+    if listed.returncode == 0 and listed.stdout.strip():
+        cmds = sorted({line.strip() for line in listed.stdout.splitlines() if line.strip()})
+        if cmds:
+            return cmds
+
     src = (project_root / "test" / source_name).read_text()
-    # Capture the whole quoted value rather than assuming a character class.
-    # An earlier lowercase-only pattern silently skipped
-    # --test-getHit-after-construct, which is exactly the kind of gap this file
-    # exists to prevent.
     cmds = sorted(set(re.findall(r'cmd == "(--test-[^"]+)"', src)))
     if not cmds:
         raise AssertionError(f"No --test-* commands discovered in {source_name}")
@@ -105,7 +124,7 @@ def test_every_native_command_runs_and_passes():
     failures = []
     for source_name, exe_name in SUITES.items():
         exe = find_executable(exe_name)
-        for cmd in discover_commands(source_name):
+        for cmd in discover_commands(source_name, exe):
             problem = check(exe, cmd)
             if problem:
                 failures.append(f"{exe_name} {cmd}: {problem}")
@@ -125,7 +144,7 @@ def main() -> int:
             print(f"\nERROR: {exc}")
             return 1
 
-        commands = discover_commands(source_name)
+        commands = discover_commands(source_name, exe)
         print(f"\n{exe_name}: {len(commands)} commands discovered in {source_name}")
         for cmd in commands:
             total += 1

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -91,10 +91,52 @@ class TestFftBackend:
         assert result["passed"] > 0
 
 
+class TestRingBuffer:
+    """The capture buffer.
+
+    Not rack::dsp::RingBuffer, whose capacity is a template parameter and so
+    cannot depend on sample rate. This one allocates once at construction and
+    never reallocates, which is what makes the audio-thread write path safe.
+    """
+
+    def test_written_samples_read_back_bit_exact(self):
+        result = run_test(["--test-buffer-roundtrip"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_wraparound_overwrites_oldest(self):
+        """Writing past capacity must drop the oldest frames, not corrupt or grow.
+
+        Index 0 stays the oldest surviving frame so callers see a stable
+        timeline however far the write head has wrapped.
+        """
+        result = run_test(["--test-buffer-wraparound"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_no_reallocation_after_construction(self):
+        """Capacity and storage address must be stable for the object's life.
+
+        A reallocation on the audio thread would be a real-time violation, and
+        would invalidate any pointer a reader was holding.
+        """
+        result = run_test(["--test-buffer-no-alloc"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_fractional_reads_interpolate(self):
+        """Vari-speed playback reads at fractional positions."""
+        result = run_test(["--test-buffer-interpolate"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_capacity_follows_rate_and_duration_cap(self):
+        """Capacity is sampleRate * maxSeconds, which is how the spec's 32
+        second cap is enforced across 44.1k, 48k and 96k."""
+        result = run_test(["--test-buffer-capacity"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+
 def run_all_tests() -> bool:
     passed = failed = 0
     errors = []
-    for cls in (TestFftBackend,):
+    for cls in (TestFftBackend, TestRingBuffer):
         instance = cls()
         for name in dir(instance):
             if not name.startswith("test_"):

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -126,6 +126,26 @@ class TestRingBuffer:
         result = run_test(["--test-buffer-interpolate"])
         assert result["failed"] == 0, result.get("detail", "")
 
+    def test_non_finite_positions_are_rejected(self):
+        """inf and NaN playback positions must give silence, not NaN audio.
+
+        Casting inf or NaN to size_t is undefined behaviour, and NaN slips past
+        a bare `position < 0` guard because every NaN comparison is false. NaN
+        audio would then propagate through the entire patch.
+        """
+        result = run_test(["--test-buffer-non-finite"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_clear_does_not_touch_storage(self):
+        """clear() must be O(1) and audio-thread safe.
+
+        Zeroing the allocation is up to 24.6 MB at 96 kHz stereo over the
+        32 second cap, written synchronously exactly when a new take starts.
+        Resetting the counters already makes old samples unreachable.
+        """
+        result = run_test(["--test-buffer-clear-cheap"])
+        assert result["failed"] == 0, result.get("detail", "")
+
     def test_capacity_follows_rate_and_duration_cap(self):
         """Capacity is sampleRate * maxSeconds, which is how the spec's 32
         second cap is enforced across 44.1k, 48k and 96k."""


### PR DESCRIPTION
Closes #70. Epic #90.

## Why not the SDK ring buffer

`rack::dsp::RingBuffer` is `template <typename T, size_t S>` with capacity fixed at compile time, so it cannot back a buffer whose length depends on sample rate. This one allocates once at construction from `sampleRate * maxSeconds` and never reallocates, which is what makes the audio-thread write path safe.

At the spec's 32 second cap that is about 12.3 MB at 48 kHz stereo and 24.6 MB at 96 kHz.

## Three design decisions

**`readFrame(0)` is the oldest surviving frame, not the physical start of storage.** Callers see a stable timeline however far the write head has wrapped, which lets the transport in S4 treat position as a plain index rather than tracking wrap state itself.

**Out-of-range reads return silence** rather than reading whatever happens to be in storage. That directly covers the empty-buffer state, which per the spec is what the module is in every time a patch loads.

**`readFrameInterpolated` holds the final frame** rather than wrapping to the start, so a read at the very end cannot splice in unrelated audio from the buffer's beginning.

`resize()` exists for sample-rate changes and is documented as **not** audio-thread safe, since it reallocates. Contents are discarded because resampling them is the caller's decision.

## Tests

| Test | Guards against |
|---|---|
| Bit-exact round-trip | Interleaving and indexing errors |
| Wraparound at 1.5x capacity | Silent corruption or unbounded growth |
| No reallocation | RT violation, dangling reader pointers |
| Fractional interpolation | Vari-speed playback artefacts |
| Capacity at 44.1k / 48k / 96k | The 32 second cap not being enforced |

Red-green: all five failed to compile before `RingBuffer.hpp` existed, all pass after.

`stems_test --self-test`: **4 to 9 checks**. `just test-native` green, coverage guard at 38 commands.