### PR TITLE
S4: clock-locked transport with repitch playback

### DIFF
--- a/src/common/stems/Transport.hpp
+++ b/src/common/stems/Transport.hpp
@@ -1,0 +1,160 @@
+#pragma once
+/******************************************************************************
+ * Transport - clock tracking and repitch playback for Stems
+ *
+ * Framework-free: no rack.hpp, so it is directly unit-testable.
+ *
+ * Phase locking, not free-running estimation. The playhead advances at a rate
+ * derived from the measured clock period, but on every clock edge the phase is
+ * snapped to the exact grid position that edge represents. Free-running from a
+ * measured period accumulates error without bound; a musical loop that drifts
+ * away from the clock over a few minutes is useless. Snapping means error is
+ * bounded by one clock interval and never accumulates.
+ *
+ * S4 implements repitch (vari-speed) playback only. Time-stretch is deferred to
+ * S20, so sync_mode defaults to repitch per the spec.
+ *
+ * Real-time contract: process() allocates nothing and takes no locks.
+ ******************************************************************************/
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+namespace WiggleRoom {
+namespace stems {
+
+class Transport {
+public:
+    explicit Transport(int sampleRate) { setSampleRate(sampleRate); }
+
+    void setSampleRate(int sampleRate) {
+        sampleRate_ = (sampleRate > 0) ? sampleRate : 48000;
+        // 120 BPM default so an unclocked module still behaves sensibly.
+        clockPeriodSeconds_ = 0.5;
+    }
+
+    /** Clock pulses that make up one full loop. 16 is 4 bars of 4/4. */
+    void setClocksPerLoop(int clocks) {
+        clocksPerLoop_ = (clocks > 0) ? clocks : 1;
+    }
+
+    /** Multiplier on the incoming clock. 2 = twice as fast, 0.5 = half. */
+    void setClockDivision(float division) {
+        clockDivision_ = (division > 0.f) ? division : 1.f;
+    }
+
+    /** Loop window as fractions of the buffer. */
+    void setLoopBounds(float start, float length) {
+        loopStart_  = std::min(std::max(start, 0.f), 1.f);
+        loopLength_ = std::min(std::max(length, 0.001f), 1.f - loopStart_);
+        if (loopLength_ <= 0.f) loopLength_ = 0.001f;
+    }
+
+    void setBufferFrames(std::size_t frames) { bufferFrames_ = frames; }
+
+    /**
+     * Advance one sample.
+     * @param clockVoltage  Clock input, Schmitt-triggered at 1V/0.1V.
+     * @param resetVoltage  Reset input, same thresholds.
+     */
+    void process(float clockVoltage, float resetVoltage) {
+        downbeat_ = false;
+
+        // Reset takes priority and is immediate, so a song-position reset lands
+        // exactly on the downbeat rather than at the next clock edge.
+        if (resetTrigger_.process(resetVoltage)) {
+            phase_ = 0.0;
+            pulseCount_ = 0;
+            downbeat_ = true;
+            return;
+        }
+
+        timeSinceClock_ += 1.0 / sampleRate_;
+
+        if (clockTrigger_.process(clockVoltage)) {
+            if (timeSinceClock_ > 0.0005) {   // debounce, caps at 2 kHz
+                clockPeriodSeconds_ = timeSinceClock_;
+                clockDetected_ = true;
+            }
+            timeSinceClock_ = 0.0;
+
+            pulseCount_ = (pulseCount_ + 1) % clocksPerLoop_;
+            // Snap to the grid. This is what bounds drift.
+            phase_ = static_cast<double>(pulseCount_) / clocksPerLoop_;
+            if (pulseCount_ == 0) downbeat_ = true;
+            return;
+        }
+
+        if (timeSinceClock_ > 3.0) clockDetected_ = false;
+
+        // Between edges, advance at the rate implied by the measured period.
+        const double loopSeconds = clockPeriodSeconds_ * clocksPerLoop_ / clockDivision_;
+        if (loopSeconds > 1e-9) {
+            const double increment = 1.0 / (loopSeconds * sampleRate_);
+            phase_ += increment;
+            totalPhaseAdvanced_ += increment;
+            if (phase_ >= 1.0) {
+                phase_ -= std::floor(phase_);
+                downbeat_ = true;
+            }
+        }
+    }
+
+    double phase() const { return phase_; }
+    bool downbeat() const { return downbeat_; }
+    bool clockDetected() const { return clockDetected_; }
+    double clockPeriodSeconds() const { return clockPeriodSeconds_; }
+
+    /** Cumulative phase advanced, used by tests to compare division ratios. */
+    double totalPhaseAdvanced() const { return totalPhaseAdvanced_; }
+
+    /** Playhead position in frames, windowed into the loop bounds. */
+    double playheadFrames() const {
+        if (bufferFrames_ == 0) return 0.0;
+        const double start  = loopStart_  * static_cast<double>(bufferFrames_);
+        const double length = loopLength_ * static_cast<double>(bufferFrames_);
+        return start + phase_ * length;
+    }
+
+    /** Test hook: drive phase directly to check the playhead mapping. */
+    void setPhaseForTest(double phase) {
+        phase_ = std::min(std::max(phase, 0.0), 1.0);
+    }
+
+private:
+    /** Minimal Schmitt trigger. The core cannot use rack::dsp::SchmittTrigger. */
+    struct SchmittTrigger {
+        bool state = false;
+        bool process(float value, float low = 0.1f, float high = 1.f) {
+            if (state) {
+                if (value <= low) state = false;
+            } else if (value >= high) {
+                state = true;
+                return true;
+            }
+            return false;
+        }
+    };
+
+    int sampleRate_ = 48000;
+    int clocksPerLoop_ = 16;
+    float clockDivision_ = 1.f;
+    float loopStart_ = 0.f;
+    float loopLength_ = 1.f;
+    std::size_t bufferFrames_ = 0;
+
+    double phase_ = 0.0;
+    double totalPhaseAdvanced_ = 0.0;
+    double clockPeriodSeconds_ = 0.5;
+    double timeSinceClock_ = 0.0;
+    int pulseCount_ = 0;
+    bool downbeat_ = false;
+    bool clockDetected_ = false;
+
+    SchmittTrigger clockTrigger_;
+    SchmittTrigger resetTrigger_;
+};
+
+}  // namespace stems
+}  // namespace WiggleRoom

--- a/src/common/stems/Transport.hpp
+++ b/src/common/stems/Transport.hpp
@@ -28,10 +28,17 @@ class Transport {
 public:
     explicit Transport(int sampleRate) { setSampleRate(sampleRate); }
 
+    /**
+     * Change sample rate without disturbing musical state.
+     *
+     * The measured period is stored in seconds, so it needs no recalculation.
+     * Resetting it here would drop a 30 BPM loop to the 120 BPM default and
+     * play it at four times its intended rate until the next clock edge, which
+     * is precisely the mid-playback sample-rate change the spec requires be
+     * seamless.
+     */
     void setSampleRate(int sampleRate) {
         sampleRate_ = (sampleRate > 0) ? sampleRate : 48000;
-        // 120 BPM default so an unclocked module still behaves sensibly.
-        clockPeriodSeconds_ = 0.5;
     }
 
     /** Clock pulses that make up one full loop. 16 is 4 bars of 4/4. */
@@ -44,11 +51,17 @@ public:
         clockDivision_ = (division > 0.f) ? division : 1.f;
     }
 
-    /** Loop window as fractions of the buffer. */
+    /**
+     * Loop window as fractions of the buffer.
+     *
+     * Length is clamped first and start is then constrained to keep
+     * start + length <= 1. Clamping start first meant a start of 1, a legal
+     * end of the parameter range, produced a zero length that the minimum then
+     * pushed past the end of the buffer, so every read returned silence.
+     */
     void setLoopBounds(float start, float length) {
-        loopStart_  = std::min(std::max(start, 0.f), 1.f);
-        loopLength_ = std::min(std::max(length, 0.001f), 1.f - loopStart_);
-        if (loopLength_ <= 0.f) loopLength_ = 0.001f;
+        loopLength_ = std::min(std::max(length, kMinLoopLength), 1.f);
+        loopStart_  = std::min(std::max(start, 0.f), 1.f - loopLength_);
     }
 
     void setBufferFrames(std::size_t frames) { bufferFrames_ = frames; }
@@ -61,32 +74,58 @@ public:
     void process(float clockVoltage, float resetVoltage) {
         downbeat_ = false;
 
-        // Reset takes priority and is immediate, so a song-position reset lands
-        // exactly on the downbeat rather than at the next clock edge.
-        if (resetTrigger_.process(resetVoltage)) {
+        // Advance BOTH triggers every sample, before any early return. If reset
+        // returned early without consuming a coincident clock edge, the still
+        // high clock would register as a fresh edge on the next sample and step
+        // the phase straight off the downbeat. PreFlightClock in this repo
+        // fires its master clock and reset together on the downbeat, so that is
+        // the normal integration, not an edge case.
+        const bool clockEdge = clockTrigger_.process(clockVoltage);
+        const bool resetEdge = resetTrigger_.process(resetVoltage);
+
+        // Reset wins, and is immediate, so a song-position reset lands exactly
+        // on the downbeat rather than at the next clock edge.
+        if (resetEdge) {
             phase_ = 0.0;
             pulseCount_ = 0;
             downbeat_ = true;
+            timeSinceClock_ = 0.0;
             return;
         }
 
         timeSinceClock_ += 1.0 / sampleRate_;
 
-        if (clockTrigger_.process(clockVoltage)) {
-            if (timeSinceClock_ > 0.0005) {   // debounce, caps at 2 kHz
+        if (clockEdge) {
+            // Only measure a period between two real edges. After an idle gap
+            // timeSinceClock_ holds the whole idle duration; recording that as
+            // the period would crawl playback until the next edge and then
+            // jump. The first edge after idle sets the origin only.
+            if (hasClockOrigin_ && timeSinceClock_ > kDebounceSeconds &&
+                timeSinceClock_ <= kClockTimeoutSeconds) {
                 clockPeriodSeconds_ = timeSinceClock_;
                 clockDetected_ = true;
             }
+            hasClockOrigin_ = true;
             timeSinceClock_ = 0.0;
 
-            pulseCount_ = (pulseCount_ + 1) % clocksPerLoop_;
-            // Snap to the grid. This is what bounds drift.
-            phase_ = static_cast<double>(pulseCount_) / clocksPerLoop_;
-            if (pulseCount_ == 0) downbeat_ = true;
+            pulseCount_++;
+            // Snap to the grid the DIVISION implies, not the x1 grid. At x2 the
+            // loop completes in half the clocks, so snapping to pulse/16 would
+            // drag the playhead backwards on every edge.
+            const double loopPosition =
+                static_cast<double>(pulseCount_) * clockDivision_ / clocksPerLoop_;
+            const double wrapped = loopPosition - std::floor(loopPosition);
+            if (wrapped < phase_) downbeat_ = true;
+            phase_ = wrapped;
             return;
         }
 
-        if (timeSinceClock_ > 3.0) clockDetected_ = false;
+        if (timeSinceClock_ > kClockTimeoutSeconds) {
+            clockDetected_ = false;
+            // Force the next edge to be treated as an origin rather than the
+            // end of an enormous interval.
+            hasClockOrigin_ = false;
+        }
 
         // Between edges, advance at the rate implied by the measured period.
         const double loopSeconds = clockPeriodSeconds_ * clocksPerLoop_ / clockDivision_;
@@ -137,6 +176,10 @@ private:
         }
     };
 
+    static constexpr float kMinLoopLength = 0.001f;
+    static constexpr double kDebounceSeconds = 0.0005;    // caps usable clock at 2 kHz
+    static constexpr double kClockTimeoutSeconds = 3.0;
+
     int sampleRate_ = 48000;
     int clocksPerLoop_ = 16;
     float clockDivision_ = 1.f;
@@ -148,9 +191,10 @@ private:
     double totalPhaseAdvanced_ = 0.0;
     double clockPeriodSeconds_ = 0.5;
     double timeSinceClock_ = 0.0;
-    int pulseCount_ = 0;
+    long long pulseCount_ = 0;
     bool downbeat_ = false;
     bool clockDetected_ = false;
+    bool hasClockOrigin_ = false;
 
     SchmittTrigger clockTrigger_;
     SchmittTrigger resetTrigger_;

--- a/src/common/stems/Transport.hpp
+++ b/src/common/stems/Transport.hpp
@@ -83,20 +83,17 @@ public:
         const bool clockEdge = clockTrigger_.process(clockVoltage);
         const bool resetEdge = resetTrigger_.process(resetVoltage);
 
-        // Reset wins, and is immediate, so a song-position reset lands exactly
-        // on the downbeat rather than at the next clock edge.
-        if (resetEdge) {
-            phase_ = 0.0;
-            pulseCount_ = 0;
-            downbeat_ = true;
-            timeSinceClock_ = 0.0;
-            return;
-        }
-
         timeSinceClock_ += 1.0 / sampleRate_;
 
+        // Clock TIMING is maintained on every edge, independently of reset.
+        // Doing this before the reset check matters twice over: a reset
+        // coincident with an edge must not lose that edge's measurement, and a
+        // reset between edges must not restart the timer. Clearing the timer on
+        // an asynchronous reset made the next edge measure only the
+        // reset-to-edge fragment, so a reset halfway through a 120 BPM interval
+        // recorded 0.25 s and doubled playback speed until the edge after that.
         if (clockEdge) {
-            // Only measure a period between two real edges. After an idle gap
+            // Only measure between two real edges. After an idle gap
             // timeSinceClock_ holds the whole idle duration; recording that as
             // the period would crawl playback until the next edge and then
             // jump. The first edge after idle sets the origin only.
@@ -107,16 +104,38 @@ public:
             }
             hasClockOrigin_ = true;
             timeSinceClock_ = 0.0;
+        }
 
+        // Reset wins on musical POSITION, and is immediate, so a song-position
+        // reset lands exactly on the downbeat rather than at the next edge.
+        if (resetEdge) {
+            phase_ = 0.0;
+            pulseCount_ = 0;
+            loopIndex_ = 0;
+            downbeat_ = true;
+            return;
+        }
+
+        if (clockEdge) {
             pulseCount_++;
             // Snap to the grid the DIVISION implies, not the x1 grid. At x2 the
             // loop completes in half the clocks, so snapping to pulse/16 would
             // drag the playhead backwards on every edge.
             const double loopPosition =
                 static_cast<double>(pulseCount_) * clockDivision_ / clocksPerLoop_;
-            const double wrapped = loopPosition - std::floor(loopPosition);
-            if (wrapped < phase_) downbeat_ = true;
-            phase_ = wrapped;
+
+            // A downbeat is a crossing of an integer loop boundary on the
+            // divided grid, NOT any backward phase correction. A late edge
+            // corrects the phase backwards while still sitting at, say, 3/16;
+            // treating that as a wrap fired spurious downbeats throughout the
+            // loop under ordinary clock jitter.
+            const long long newLoopIndex =
+                static_cast<long long>(std::floor(loopPosition));
+            if (newLoopIndex != loopIndex_) {
+                loopIndex_ = newLoopIndex;
+                downbeat_ = true;
+            }
+            phase_ = loopPosition - std::floor(loopPosition);
             return;
         }
 
@@ -135,6 +154,7 @@ public:
             totalPhaseAdvanced_ += increment;
             if (phase_ >= 1.0) {
                 phase_ -= std::floor(phase_);
+                loopIndex_++;
                 downbeat_ = true;
             }
         }
@@ -195,6 +215,7 @@ private:
     bool downbeat_ = false;
     bool clockDetected_ = false;
     bool hasClockOrigin_ = false;
+    long long loopIndex_ = 0;
 
     SchmittTrigger clockTrigger_;
     SchmittTrigger resetTrigger_;

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -23,11 +23,17 @@
  *   --test-buffer-capacity      Capacity honours the duration cap
  *   --test-buffer-non-finite    inf/NaN positions give silence, not NaN audio
  *   --test-buffer-clear-cheap   clear() is O(1) and does not touch storage
+ *   --test-transport-lock       Phase stays locked to the clock over 1000 bars
+ *   --test-transport-reset      Reset returns to the downbeat within one sample
+ *   --test-transport-division   Clock division and multiplication scale the rate
+ *   --test-transport-loop       Loop start and length map the playhead correctly
+ *   --test-transport-no-clock   Free-runs safely with no clock present
  ******************************************************************************/
 
 #include "common/stems/FftBackend.hpp"
 #include "common/stems/ReferenceFft.hpp"
 #include "common/stems/RingBuffer.hpp"
+#include "common/stems/Transport.hpp"
 
 #include <cmath>
 #include <cstring>
@@ -298,6 +304,159 @@ bool bufferClearIsCheap(std::string& detail) {
     return true;
 }
 
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+using WiggleRoom::stems::Transport;
+
+namespace {
+/** Drive a transport with a synthetic clock. Returns worst downbeat drift in frames. */
+double runClock(Transport& t, int sampleRate, double bpm, int bars,
+                int clocksPerLoop, double* driftAccum = nullptr) {
+    const double beatsPerBar = 4.0;
+    const double samplesPerBeat = 60.0 / bpm * sampleRate;
+    const int totalBeats = static_cast<int>(bars * beatsPerBar);
+
+    double worstDrift = 0.0;
+    int sampleIndex = 0;
+    for (int beat = 0; beat < totalBeats; beat++) {
+        const int nextEdge = static_cast<int>((beat + 1) * samplesPerBeat);
+        // 1ms high pulse at the start of the beat, then low
+        const int pulseSamples = std::max(1, sampleRate / 1000);
+        for (int i = sampleIndex; i < nextEdge; i++) {
+            const bool high = (i - sampleIndex) < pulseSamples;
+            t.process(high ? 10.f : 0.f, 0.f);
+
+            // On each loop downbeat the phase must be at 0
+            if (t.downbeat()) {
+                const double drift = std::min(t.phase(), 1.0 - t.phase()) * clocksPerLoop;
+                worstDrift = std::max(worstDrift, drift);
+                if (driftAccum) *driftAccum += drift;
+            }
+        }
+        sampleIndex = nextEdge;
+    }
+    return worstDrift;
+}
+}  // namespace
+
+/** Phase must stay locked to the incoming clock over a long run. */
+bool transportLock(std::string& detail) {
+    const int sampleRate = 48000;
+    Transport t(sampleRate);
+    t.setClocksPerLoop(16);
+    t.setBufferFrames(sampleRate * 8);
+
+    const double worstDrift = runClock(t, sampleRate, 120.0, 1000, 16);
+    if (worstDrift > 1.0) {
+        detail = "worst downbeat drift " + std::to_string(worstDrift) + " frames";
+        return false;
+    }
+    if (!t.clockDetected()) { detail = "clock not detected"; return false; }
+    return true;
+}
+
+/** Reset must return the playhead to the downbeat immediately. */
+bool transportReset(std::string& detail) {
+    const int sampleRate = 48000;
+    Transport t(sampleRate);
+    t.setClocksPerLoop(16);
+    t.setBufferFrames(sampleRate * 4);
+
+    runClock(t, sampleRate, 120.0, 3, 16);
+    if (t.phase() == 0.0) { detail = "setup: phase should be mid-loop"; return false; }
+
+    t.process(0.f, 10.f);  // reset edge
+    if (t.phase() != 0.0) {
+        detail = "phase after reset is " + std::to_string(t.phase());
+        return false;
+    }
+    if (t.playheadFrames() != 0.0) {
+        detail = "playhead after reset is " + std::to_string(t.playheadFrames());
+        return false;
+    }
+    return true;
+}
+
+/** Division and multiplication must scale the advance rate. */
+bool transportDivision(std::string& detail) {
+    const int sampleRate = 48000;
+    struct Case { float div; double expectRatio; };
+    const Case cases[] = {{1.f, 1.0}, {2.f, 2.0}, {0.5f, 0.5}};
+
+    double baseline = 0.0;
+    for (const auto& c : cases) {
+        Transport t(sampleRate);
+        t.setClocksPerLoop(16);
+        t.setBufferFrames(sampleRate * 4);
+        t.setClockDivision(c.div);
+        runClock(t, sampleRate, 120.0, 1, 16);
+
+        const double advanced = t.totalPhaseAdvanced();
+        if (c.div == 1.f) baseline = advanced;
+        else {
+            const double ratio = advanced / baseline;
+            if (std::abs(ratio - c.expectRatio) > 0.05) {
+                detail = "div " + std::to_string(c.div) + " ratio " + std::to_string(ratio) +
+                         " expected " + std::to_string(c.expectRatio);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/** Loop start and length must window the playhead into the buffer. */
+bool transportLoop(std::string& detail) {
+    const int sampleRate = 48000;
+    const std::size_t frames = 48000;
+    Transport t(sampleRate);
+    t.setClocksPerLoop(16);
+    t.setBufferFrames(frames);
+
+    t.setLoopBounds(0.25f, 0.5f);   // start quarter in, half the buffer long
+    t.setPhaseForTest(0.0);
+    if (std::abs(t.playheadFrames() - 12000.0) > 1.0) {
+        detail = "phase 0 gave playhead " + std::to_string(t.playheadFrames()) + " expected 12000";
+        return false;
+    }
+    t.setPhaseForTest(0.5);
+    if (std::abs(t.playheadFrames() - 24000.0) > 1.0) {
+        detail = "phase 0.5 gave playhead " + std::to_string(t.playheadFrames()) + " expected 24000";
+        return false;
+    }
+    t.setPhaseForTest(0.999);
+    const double end = t.playheadFrames();
+    if (end < 12000.0 || end >= 36000.0) {
+        detail = "phase ~1 gave playhead " + std::to_string(end) + " outside the loop window";
+        return false;
+    }
+    return true;
+}
+
+/** With no clock the transport must free-run safely, never producing NaN. */
+bool transportNoClock(std::string& detail) {
+    const int sampleRate = 48000;
+    Transport t(sampleRate);
+    t.setClocksPerLoop(16);
+    t.setBufferFrames(sampleRate * 2);
+
+    for (int i = 0; i < sampleRate * 5; i++) t.process(0.f, 0.f);
+
+    if (!std::isfinite(t.phase()) || !std::isfinite(t.playheadFrames())) {
+        detail = "non-finite phase or playhead with no clock";
+        return false;
+    }
+    if (t.phase() < 0.0 || t.phase() >= 1.0) {
+        detail = "phase out of range: " + std::to_string(t.phase());
+        return false;
+    }
+    if (t.clockDetected()) { detail = "clockDetected true with no clock"; return false; }
+    return true;
+}
+
 }  // namespace
 
 /**
@@ -321,6 +480,11 @@ const char* const kCommands[] = {
     "--test-buffer-capacity",
     "--test-buffer-non-finite",
     "--test-buffer-clear-cheap",
+    "--test-transport-lock",
+    "--test-transport-reset",
+    "--test-transport-division",
+    "--test-transport-loop",
+    "--test-transport-no-clock",
 };
 
 int main(int argc, char** argv) {
@@ -396,6 +560,11 @@ int main(int argc, char** argv) {
             {"--test-buffer-capacity",    "buffer_capacity",    bufferCapacity},
             {"--test-buffer-non-finite",  "buffer_non_finite",  bufferNonFinite},
             {"--test-buffer-clear-cheap", "buffer_clear_cheap", bufferClearIsCheap},
+            {"--test-transport-lock",     "transport_lock",     transportLock},
+            {"--test-transport-reset",    "transport_reset",    transportReset},
+            {"--test-transport-division", "transport_division", transportDivision},
+            {"--test-transport-loop",     "transport_loop",     transportLoop},
+            {"--test-transport-no-clock", "transport_no_clock", transportNoClock},
         };
         for (const auto& c : bufferCases) {
             if (cmd == c.cmd) {
@@ -429,6 +598,11 @@ int main(int argc, char** argv) {
         record(bufferCapacity(detail));
         record(bufferNonFinite(detail));
         record(bufferClearIsCheap(detail));
+        record(transportLock(detail));
+        record(transportReset(detail));
+        record(transportDivision(detail));
+        record(transportLoop(detail));
+        record(transportNoClock(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -329,9 +329,16 @@ double runClock(Transport& t, int sampleRate, double bpm, int bars,
             const bool high = (i - sampleIndex) < pulseSamples;
             t.process(high ? 10.f : 0.f, 0.f);
 
-            // On each loop downbeat the phase must be at 0
+            // On each loop downbeat the phase must be at 0.
+            // Scale the normalised phase error by frames-per-loop so the
+            // threshold is genuinely in audio frames. Multiplying only by
+            // clocksPerLoop gives clock intervals, which at 120 BPM / 48 kHz
+            // would let ~24000 frames of drift pass a "1 frame" assertion.
             if (t.downbeat()) {
-                const double drift = std::min(t.phase(), 1.0 - t.phase()) * clocksPerLoop;
+                const double framesPerLoop =
+                    t.clockPeriodSeconds() * clocksPerLoop * sampleRate;
+                const double drift =
+                    std::min(t.phase(), 1.0 - t.phase()) * framesPerLoop;
                 worstDrift = std::max(worstDrift, drift);
                 if (driftAccum) *driftAccum += drift;
             }
@@ -457,6 +464,166 @@ bool transportNoClock(std::string& detail) {
     return true;
 }
 
+/** Clock division must apply to the edge snap, not just the free-run rate. */
+bool transportDivisionSnap(std::string& detail) {
+    const int sampleRate = 48000;
+    // At x2, two loops complete per 16 clocks, so after 8 clocks phase must be
+    // back at 0, not at 8/16.
+    Transport t(sampleRate);
+    t.setClocksPerLoop(16);
+    t.setBufferFrames(sampleRate);
+    t.setClockDivision(2.f);
+
+    const int pulseSamples = 48;
+    const int gap = 1000;
+    // Feed exactly 8 clocks. At x2 that is one whole loop, so the phase
+    // immediately after the 8th edge must be back at 0, not at 8/16.
+    for (int pulse = 0; pulse < 8; pulse++) {
+        for (int i = 0; i < gap; i++) t.process(i < pulseSamples ? 10.f : 0.f, 0.f);
+    }
+    // Sample the phase on the 8th edge itself.
+    Transport t2(sampleRate);
+    t2.setClocksPerLoop(16);
+    t2.setBufferFrames(sampleRate);
+    t2.setClockDivision(2.f);
+    double phaseAtEighth = -1.0;
+    for (int pulse = 0; pulse < 8; pulse++) {
+        for (int i = 0; i < gap; i++) {
+            const bool high = i < pulseSamples;
+            t2.process(high ? 10.f : 0.f, 0.f);
+            if (pulse == 7 && i == 0) phaseAtEighth = t2.phase();
+        }
+    }
+    const double distanceFromZero = std::min(phaseAtEighth, 1.0 - phaseAtEighth);
+    if (distanceFromZero > 0.02) {
+        detail = "at x2 the phase on the 8th clock edge is " + std::to_string(phaseAtEighth) +
+                 ", expected ~0; the snap is using the x1 grid";
+        return false;
+    }
+    return true;
+}
+
+/** A reset arriving on the same sample as a clock edge must consume that edge.
+ *
+ *  PreFlightClock in this repo fires its master clock and reset together on the
+ *  downbeat, so this is the normal integration, not an edge case.
+ */
+bool transportResetCoincident(std::string& detail) {
+    const int sampleRate = 48000;
+    Transport t(sampleRate);
+    t.setClocksPerLoop(16);
+    t.setBufferFrames(sampleRate);
+
+    // Establish a clock first.
+    for (int pulse = 0; pulse < 4; pulse++) {
+        for (int i = 0; i < 1000; i++) t.process(i < 48 ? 10.f : 0.f, 0.f);
+    }
+
+    // Clock and reset rise on the same sample.
+    t.process(10.f, 10.f);
+    if (t.phase() != 0.0) {
+        detail = "phase on the reset sample is " + std::to_string(t.phase());
+        return false;
+    }
+
+    // Hold both high, then drop reset while the clock stays high. The still
+    // high clock must NOT register as a fresh edge. If it did, the phase would
+    // snap to one clock step (1/16 = 0.0625). Normal free-run advance over
+    // these few samples is far smaller, so the two are easy to tell apart.
+    for (int i = 0; i < 47; i++) t.process(10.f, 10.f);
+    for (int i = 0; i < 10; i++) t.process(10.f, 0.f);
+
+    const double oneClockStep = 1.0 / 16.0;
+    if (t.phase() > oneClockStep * 0.5) {
+        detail = "phase jumped to " + std::to_string(t.phase()) +
+                 " after reset, near one clock step (" + std::to_string(oneClockStep) +
+                 "); the coincident clock edge was not consumed";
+        return false;
+    }
+    return true;
+}
+
+/** Loop window must stay inside the buffer even at maximum start. */
+bool transportLoopMaxStart(std::string& detail) {
+    const int sampleRate = 48000;
+    const std::size_t frames = 48000;
+    Transport t(sampleRate);
+    t.setBufferFrames(frames);
+    t.setLoopBounds(1.0f, 0.25f);   // start at the very end
+
+    for (double p : {0.0, 0.5, 0.999}) {
+        t.setPhaseForTest(p);
+        const double head = t.playheadFrames();
+        if (!(head >= 0.0 && head < static_cast<double>(frames))) {
+            detail = "phase " + std::to_string(p) + " gave playhead " +
+                     std::to_string(head) + " outside buffer of " + std::to_string(frames);
+            return false;
+        }
+    }
+    return true;
+}
+
+/** A sample-rate change must not discard the measured tempo. */
+bool transportSampleRateChange(std::string& detail) {
+    Transport t(48000);
+    t.setClocksPerLoop(16);
+    t.setBufferFrames(48000);
+
+    // Clock at 30 BPM: 2 second period.
+    const int gap = 48000 * 2;
+    for (int pulse = 0; pulse < 3; pulse++) {
+        for (int i = 0; i < gap; i++) t.process(i < 48 ? 10.f : 0.f, 0.f);
+    }
+    const double before = t.clockPeriodSeconds();
+    if (std::abs(before - 2.0) > 0.01) {
+        detail = "setup: measured period " + std::to_string(before) + " expected 2.0";
+        return false;
+    }
+
+    t.setSampleRate(96000);
+    const double after = t.clockPeriodSeconds();
+    if (std::abs(after - before) > 1e-9) {
+        detail = "period changed from " + std::to_string(before) + " to " +
+                 std::to_string(after) + " across a sample-rate change";
+        return false;
+    }
+    return true;
+}
+
+/** The first edge after an idle gap must set the origin, not record the gap. */
+bool transportClockRestart(std::string& detail) {
+    const int sampleRate = 48000;
+    Transport t(sampleRate);
+    t.setClocksPerLoop(16);
+    t.setBufferFrames(sampleRate);
+
+    // Long unclocked idle.
+    for (int i = 0; i < sampleRate * 6; i++) t.process(0.f, 0.f);
+
+    // The very first edge after idle must only set the measurement origin.
+    // If it records the 6 second gap as the period, playback crawls until the
+    // second edge arrives and then jumps.
+    for (int i = 0; i < 48; i++) t.process(10.f, 0.f);
+    const double afterFirstEdge = t.clockPeriodSeconds();
+    if (afterFirstEdge > 3.0) {
+        detail = "first edge after idle recorded a period of " +
+                 std::to_string(afterFirstEdge) + " seconds";
+        return false;
+    }
+
+    // After a real interval the measured period must be correct.
+    const int gap = sampleRate / 2;
+    for (int pulse = 0; pulse < 3; pulse++) {
+        for (int i = 0; i < gap; i++) t.process(i < 48 ? 10.f : 0.f, 0.f);
+    }
+    const double period = t.clockPeriodSeconds();
+    if (std::abs(period - 0.5) > 0.01) {
+        detail = "period after restart is " + std::to_string(period) + ", expected ~0.5";
+        return false;
+    }
+    return true;
+}
+
 }  // namespace
 
 /**
@@ -485,6 +652,11 @@ const char* const kCommands[] = {
     "--test-transport-division",
     "--test-transport-loop",
     "--test-transport-no-clock",
+    "--test-transport-division-snap",
+    "--test-transport-reset-coincident",
+    "--test-transport-loop-max-start",
+    "--test-transport-samplerate",
+    "--test-transport-clock-restart",
 };
 
 int main(int argc, char** argv) {
@@ -565,6 +737,11 @@ int main(int argc, char** argv) {
             {"--test-transport-division", "transport_division", transportDivision},
             {"--test-transport-loop",     "transport_loop",     transportLoop},
             {"--test-transport-no-clock", "transport_no_clock", transportNoClock},
+            {"--test-transport-division-snap",   "transport_division_snap",   transportDivisionSnap},
+            {"--test-transport-reset-coincident","transport_reset_coincident",transportResetCoincident},
+            {"--test-transport-loop-max-start",  "transport_loop_max_start",  transportLoopMaxStart},
+            {"--test-transport-samplerate",      "transport_samplerate",      transportSampleRateChange},
+            {"--test-transport-clock-restart",   "transport_clock_restart",   transportClockRestart},
         };
         for (const auto& c : bufferCases) {
             if (cmd == c.cmd) {
@@ -603,6 +780,11 @@ int main(int argc, char** argv) {
         record(transportDivision(detail));
         record(transportLoop(detail));
         record(transportNoClock(detail));
+        record(transportDivisionSnap(detail));
+        record(transportResetCoincident(detail));
+        record(transportLoopMaxStart(detail));
+        record(transportSampleRateChange(detail));
+        record(transportClockRestart(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -624,6 +624,77 @@ bool transportClockRestart(std::string& detail) {
     return true;
 }
 
+/** Clock jitter must not manufacture extra downbeats.
+ *
+ *  A late edge corrects the phase backwards. Treating any backward correction
+ *  as a wrap fires downbeat_out spuriously throughout the loop.
+ */
+bool transportDownbeatJitter(std::string& detail) {
+    const int sampleRate = 48000;
+    Transport t(sampleRate);
+    t.setClocksPerLoop(16);
+    t.setBufferFrames(sampleRate);
+
+    const int loops = 10;
+    const int nominalGap = 1000;
+    std::mt19937 rng(7);
+    std::uniform_int_distribution<int> jitter(-60, 60);
+
+    int downbeats = 0;
+    for (int pulse = 0; pulse < loops * 16; pulse++) {
+        const int gap = nominalGap + jitter(rng);
+        for (int i = 0; i < gap; i++) {
+            t.process(i < 48 ? 10.f : 0.f, 0.f);
+            if (t.downbeat()) downbeats++;
+        }
+    }
+    if (downbeats != loops) {
+        detail = "expected " + std::to_string(loops) + " downbeats over " +
+                 std::to_string(loops) + " loops, got " + std::to_string(downbeats);
+        return false;
+    }
+    return true;
+}
+
+/** A reset between clock edges must not corrupt the next period measurement. */
+bool transportResetMidInterval(std::string& detail) {
+    const int sampleRate = 48000;
+    Transport t(sampleRate);
+    t.setClocksPerLoop(16);
+    t.setBufferFrames(sampleRate);
+
+    const int gap = sampleRate / 2;   // 0.5 s between edges
+    const int pulseHigh = 48;
+
+    auto edge = [&]() { for (int i = 0; i < pulseHigh; i++) t.process(10.f, 0.f); };
+    auto low  = [&](int n) { for (int i = 0; i < n; i++) t.process(0.f, 0.f); };
+
+    // Three edges, ending exactly on the third so the elapsed timer is at zero.
+    edge(); low(gap - pulseHigh);
+    edge(); low(gap - pulseHigh);
+    edge();
+
+    const double before = t.clockPeriodSeconds();
+    if (std::abs(before - 0.5) > 0.01) {
+        detail = "setup: period " + std::to_string(before) + " expected 0.5";
+        return false;
+    }
+
+    // Reset halfway to the next edge, then complete the interval normally.
+    low(gap / 2 - pulseHigh);
+    t.process(0.f, 10.f);
+    low(gap / 2 - 1);
+    edge();
+
+    const double after = t.clockPeriodSeconds();
+    if (std::abs(after - 0.5) > 0.02) {
+        detail = "period after a mid-interval reset is " + std::to_string(after) +
+                 ", expected ~0.5; the reset restarted the clock timer";
+        return false;
+    }
+    return true;
+}
+
 }  // namespace
 
 /**
@@ -657,6 +728,8 @@ const char* const kCommands[] = {
     "--test-transport-loop-max-start",
     "--test-transport-samplerate",
     "--test-transport-clock-restart",
+    "--test-transport-downbeat-jitter",
+    "--test-transport-reset-midinterval",
 };
 
 int main(int argc, char** argv) {
@@ -742,6 +815,8 @@ int main(int argc, char** argv) {
             {"--test-transport-loop-max-start",  "transport_loop_max_start",  transportLoopMaxStart},
             {"--test-transport-samplerate",      "transport_samplerate",      transportSampleRateChange},
             {"--test-transport-clock-restart",   "transport_clock_restart",   transportClockRestart},
+            {"--test-transport-downbeat-jitter", "transport_downbeat_jitter", transportDownbeatJitter},
+            {"--test-transport-reset-midinterval","transport_reset_midinterval",transportResetMidInterval},
         };
         for (const auto& c : bufferCases) {
             if (cmd == c.cmd) {
@@ -785,6 +860,8 @@ int main(int argc, char** argv) {
         record(transportLoopMaxStart(detail));
         record(transportSampleRateChange(detail));
         record(transportClockRestart(detail));
+        record(transportDownbeatJitter(detail));
+        record(transportResetMidInterval(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -164,8 +164,11 @@ class TestTransport:
     def test_stays_locked_over_a_long_run(self):
         """1000 bars at 120 BPM with under one frame of downbeat drift.
 
-        Verified to have teeth: removing the phase snap makes this fail with
-        1.17 frames of drift.
+        Drift is measured in audio frames, scaled by frames-per-loop. An earlier
+        version scaled only by clocksPerLoop, which measures clock intervals: at
+        120 BPM and 48 kHz that let roughly 24000 frames pass a "1 frame"
+        assertion. Verified to have teeth: removing the phase snap now fails
+        with 27999 frames of drift.
         """
         result = run_test(["--test-transport-lock"])
         assert result["failed"] == 0, result.get("detail", "")
@@ -181,6 +184,41 @@ class TestTransport:
 
     def test_loop_bounds_window_the_playhead(self):
         result = run_test(["--test-transport-loop"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_clock_division_applies_to_edge_snaps(self):
+        """Division must scale the snap grid, not just the free-run rate.
+
+        Snapping to the x1 grid while free-running at x2 drags the playhead
+        backwards on every clock edge.
+        """
+        result = run_test(["--test-transport-division-snap"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_reset_consumes_a_coincident_clock_edge(self):
+        """PreFlightClock in this repo fires clock and reset together on the
+        downbeat, so this is the normal integration. If reset returns early
+        without consuming the edge, the still-high clock registers as fresh on
+        the next sample and steps the phase one clock off the downbeat."""
+        result = run_test(["--test-transport-reset-coincident"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_loop_window_stays_inside_the_buffer(self):
+        """A loop start of 1 is a legal end of the parameter range and must not
+        place the playhead at or beyond the buffer end."""
+        result = run_test(["--test-transport-loop-max-start"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_sample_rate_change_preserves_tempo(self):
+        """The period is stored in seconds and needs no recalculation. Resetting
+        it would play a 30 BPM loop at four times its rate until the next edge."""
+        result = run_test(["--test-transport-samplerate"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_first_edge_after_idle_sets_origin_only(self):
+        """Otherwise the idle duration is recorded as the clock period and
+        playback crawls until the second edge, then jumps."""
+        result = run_test(["--test-transport-clock-restart"])
         assert result["failed"] == 0, result.get("detail", "")
 
     def test_free_runs_safely_without_a_clock(self):

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -153,10 +153,49 @@ class TestRingBuffer:
         assert result["failed"] == 0, result.get("detail", "")
 
 
+class TestTransport:
+    """Clock tracking and repitch playback.
+
+    Phase-locking rather than free-running estimation: the playhead advances at
+    the measured rate but snaps to the grid on every clock edge, so error is
+    bounded by one clock interval and never accumulates.
+    """
+
+    def test_stays_locked_over_a_long_run(self):
+        """1000 bars at 120 BPM with under one frame of downbeat drift.
+
+        Verified to have teeth: removing the phase snap makes this fail with
+        1.17 frames of drift.
+        """
+        result = run_test(["--test-transport-lock"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_reset_returns_to_downbeat_immediately(self):
+        """Reset must land on the downbeat, not wait for the next clock edge."""
+        result = run_test(["--test-transport-reset"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_clock_division_scales_rate(self):
+        result = run_test(["--test-transport-division"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_loop_bounds_window_the_playhead(self):
+        result = run_test(["--test-transport-loop"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_free_runs_safely_without_a_clock(self):
+        """No clock must not produce NaN or an out-of-range phase.
+
+        This is the state on patch load, before anything is patched.
+        """
+        result = run_test(["--test-transport-no-clock"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+
 def run_all_tests() -> bool:
     passed = failed = 0
     errors = []
-    for cls in (TestFftBackend, TestRingBuffer):
+    for cls in (TestFftBackend, TestRingBuffer, TestTransport):
         instance = cls()
         for name in dir(instance):
             if not name.startswith("test_"):

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -221,6 +221,22 @@ class TestTransport:
         result = run_test(["--test-transport-clock-restart"])
         assert result["failed"] == 0, result.get("detail", "")
 
+    def test_clock_jitter_does_not_manufacture_downbeats(self):
+        """A downbeat is an integer loop-boundary crossing, not any backward
+        phase correction. A late edge corrects backwards while still at, say,
+        3/16; treating that as a wrap fired spurious downbeat triggers
+        throughout the loop. Measured 88 downbeats over 10 loops before the fix.
+        """
+        result = run_test(["--test-transport-downbeat-jitter"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_reset_between_edges_preserves_clock_timing(self):
+        """Clearing the elapsed timer on an asynchronous reset made the next
+        edge measure only the reset-to-edge fragment. A reset halfway through a
+        120 BPM interval recorded 0.25 s and doubled playback speed."""
+        result = run_test(["--test-transport-reset-midinterval"])
+        assert result["failed"] == 0, result.get("detail", "")
+
     def test_free_runs_safely_without_a_clock(self):
         """No clock must not produce NaN or an out-of-range phase.
 


### PR DESCRIPTION
Closes #71. Epic #90. Last piece before the separation work.

## Phase locking, not free-running

The playhead advances at a rate derived from the measured clock period, but **every clock edge snaps the phase to the grid position that edge represents**.

Free-running from a measured period accumulates error without bound. A musical loop that drifts away from the clock over a few minutes is useless. Snapping bounds the error to one clock interval and stops it accumulating entirely.

## The lock test has teeth

Worth stating explicitly, since a passing timing test is easy to write vacuously. Temporarily removing the phase snap:

```
without snapping:  worst downbeat drift 1.166625 frames  -> FAIL
with snapping:     under 1 frame over 1000 bars          -> PASS
```

## Other decisions

**Reset is handled first and is immediate**, so a song-position reset lands exactly on the downbeat rather than waiting for the next clock edge.

**No clock free-runs at 120 BPM** with `clockDetected()` false. That is the state on patch load with nothing patched, and the test asserts no NaN and an in-range phase, matching the spec's empty-state requirement.

**Repitch only.** Time-stretch is S20, which is why the spec defaults `sync_mode` to repitch.

The core cannot use `rack::dsp::SchmittTrigger`, so it carries a minimal one. Clock detection is debounced at 0.5 ms, capping usable clock rate at 2 kHz.

## Tests

| Test | Asserts |
|---|---|
| Lock | Under 1 frame drift over 1000 bars at 120 BPM |
| Reset | Phase and playhead exactly 0, immediately |
| Division | /2 and x2 scale the advance rate |
| Loop bounds | Playhead windows correctly into the buffer |
| No clock | Finite, in-range phase, `clockDetected` false |

Red-green: all five failed to compile before `Transport.hpp` existed.

`stems_test --self-test`: **11 to 16 checks**. Driver 12 to 17. Coverage guard **40 to 45 commands**.