### PR TITLE
S5: STFT front end with perfect reconstruction

### DIFF
--- a/src/common/stems/Stft.hpp
+++ b/src/common/stems/Stft.hpp
@@ -39,10 +39,15 @@ public:
     Stft(FftBackend& fft, std::size_t hop = 0)
         : fft_(fft),
           frameSize_(fft.size()),
-          hopSize_(hop ? hop : fft.size() / 4) {
+          // Never allow a zero hop. FftBackend permits sizes down to 2, where
+          // size/4 truncates to 0 and process() would loop forever without
+          // advancing, hanging the worker thread.
+          hopSize_(std::max<std::size_t>(1, hop ? hop : fft.size() / 4)) {
         buildWindow();
         frame_.resize(frameSize_);
         spectrum_.resize(fft_.spectrumLength());
+        padded_.clear();
+        accum_.clear();
         windowSum_.clear();
     }
 
@@ -68,18 +73,27 @@ public:
     void process(const float* input, float* output, std::size_t length, ModifyFn modify) {
         if (!input || !output || length == 0) return;
 
-        std::fill(output, output + length, 0.f);
-        windowSum_.assign(length, 0.f);
+        // Zero-pad by a whole frame at each end and run the analysis over the
+        // padded signal.
+        //
+        // Without padding, two regions are silently lost: the tail after the
+        // last frame that fits (a 5000 sample input at hop 512 goes silent from
+        // 4608), and the first sample, where the Hann window is zero so no
+        // frame contributes. Both would show up as missing audio and
+        // discontinuities at loop boundaries, which is the worst possible place
+        // for them. Excluding a frame at each end in the tests merely hid this.
+        const std::size_t pad = frameSize_;
+        const std::size_t paddedLength = length + 2 * pad;
 
-        if (length < frameSize_) {
-            // Too short for even one frame. Leave silence rather than reading
-            // out of bounds; the caller sees a defined result.
-            return;
-        }
+        padded_.assign(paddedLength, 0.f);
+        std::copy(input, input + length, padded_.begin() + pad);
 
-        for (std::size_t start = 0; start + frameSize_ <= length; start += hopSize_) {
+        accum_.assign(paddedLength, 0.f);
+        windowSum_.assign(paddedLength, 0.f);
+
+        for (std::size_t start = 0; start + frameSize_ <= paddedLength; start += hopSize_) {
             for (std::size_t i = 0; i < frameSize_; i++) {
-                frame_[i] = input[start + i] * static_cast<float>(window_[i]);
+                frame_[i] = padded_[start + i] * static_cast<float>(window_[i]);
             }
 
             fft_.forward(frame_.data(), spectrum_.data());
@@ -87,16 +101,16 @@ public:
             fft_.inverse(spectrum_.data(), frame_.data());
 
             for (std::size_t i = 0; i < frameSize_; i++) {
-                output[start + i]     += frame_[i] * static_cast<float>(window_[i]);
+                accum_[start + i]     += frame_[i] * static_cast<float>(window_[i]);
                 windowSum_[start + i] += static_cast<float>(window_[i] * window_[i]);
             }
         }
 
-        // Normalise by the accumulated squared window. Doing this per sample
-        // rather than by a constant gain makes the ramp-in and ramp-out regions
-        // correct too, instead of only the steady state.
+        // Normalise by the accumulated squared window. Per sample rather than
+        // by a constant gain, so partial-overlap regions are corrected too.
         for (std::size_t i = 0; i < length; i++) {
-            if (windowSum_[i] > 1e-8f) output[i] /= windowSum_[i];
+            const float w = windowSum_[pad + i];
+            output[i] = (w > 1e-8f) ? (accum_[pad + i] / w) : 0.f;
         }
     }
 
@@ -119,6 +133,8 @@ private:
     std::vector<double> window_;
     std::vector<float> frame_;
     std::vector<float> spectrum_;
+    std::vector<float> padded_;
+    std::vector<float> accum_;
     std::vector<float> windowSum_;
 };
 

--- a/src/common/stems/Stft.hpp
+++ b/src/common/stems/Stft.hpp
@@ -1,0 +1,126 @@
+#pragma once
+/******************************************************************************
+ * Stft - short-time Fourier transform front end for Stems
+ *
+ * Framework-free: takes an FftBackend&, so the core never includes rack.hpp and
+ * stems_test can drive it with ReferenceFft.
+ *
+ * Parameters match librosa's defaults (n_fft 2048, hop = n_fft/4) so HPSS
+ * results can be validated against a reference implementation rather than only
+ * against themselves.
+ *
+ * Windowing: Hann applied on both analysis and synthesis. With hop = n/4 the
+ * squared Hann window satisfies the constant-overlap-add condition, so
+ * unmodified analysis followed by synthesis reconstructs the input up to a
+ * fixed gain, which is divided out. Applying the window on synthesis as well as
+ * analysis is what keeps a modified spectrum from producing edge discontinuities
+ * at frame boundaries, which is the whole point given HPSS will be modifying it.
+ *
+ * Not real-time: this runs on the worker thread over a whole recorded buffer,
+ * so it allocates its scratch up front but is not required to be RT-safe.
+ ******************************************************************************/
+
+#include "FftBackend.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace WiggleRoom {
+namespace stems {
+
+class Stft {
+public:
+    /**
+     * @param fft  Backend supplying the transform. Must outlive this object.
+     * @param hop  Samples between frame starts. Defaults to frameSize/4.
+     */
+    Stft(FftBackend& fft, std::size_t hop = 0)
+        : fft_(fft),
+          frameSize_(fft.size()),
+          hopSize_(hop ? hop : fft.size() / 4) {
+        buildWindow();
+        frame_.resize(frameSize_);
+        spectrum_.resize(fft_.spectrumLength());
+        windowSum_.clear();
+    }
+
+    std::size_t frameSize() const { return frameSize_; }
+    std::size_t hopSize() const { return hopSize_; }
+    std::size_t numBins() const { return fft_.numBins(); }
+
+    /** Analysis window value at index i, exposed so tests can check COLA. */
+    double windowGain(std::size_t i) const {
+        // The COLA property that matters is of the SQUARED window, since it is
+        // applied on both analysis and synthesis.
+        return window_[i] * window_[i];
+    }
+
+    /**
+     * Run analysis, an in-place spectrum callback, and synthesis.
+     *
+     * @param modify  Called once per frame with the interleaved re/im spectrum
+     *                and its length in floats. Passing an empty callback gives
+     *                pure reconstruction.
+     */
+    template <typename ModifyFn>
+    void process(const float* input, float* output, std::size_t length, ModifyFn modify) {
+        if (!input || !output || length == 0) return;
+
+        std::fill(output, output + length, 0.f);
+        windowSum_.assign(length, 0.f);
+
+        if (length < frameSize_) {
+            // Too short for even one frame. Leave silence rather than reading
+            // out of bounds; the caller sees a defined result.
+            return;
+        }
+
+        for (std::size_t start = 0; start + frameSize_ <= length; start += hopSize_) {
+            for (std::size_t i = 0; i < frameSize_; i++) {
+                frame_[i] = input[start + i] * static_cast<float>(window_[i]);
+            }
+
+            fft_.forward(frame_.data(), spectrum_.data());
+            modify(spectrum_.data(), spectrum_.size());
+            fft_.inverse(spectrum_.data(), frame_.data());
+
+            for (std::size_t i = 0; i < frameSize_; i++) {
+                output[start + i]     += frame_[i] * static_cast<float>(window_[i]);
+                windowSum_[start + i] += static_cast<float>(window_[i] * window_[i]);
+            }
+        }
+
+        // Normalise by the accumulated squared window. Doing this per sample
+        // rather than by a constant gain makes the ramp-in and ramp-out regions
+        // correct too, instead of only the steady state.
+        for (std::size_t i = 0; i < length; i++) {
+            if (windowSum_[i] > 1e-8f) output[i] /= windowSum_[i];
+        }
+    }
+
+private:
+    void buildWindow() {
+        window_.resize(frameSize_);
+        // Periodic Hann, which is the correct form for STFT overlap-add.
+        // The symmetric variant does not satisfy COLA at hop = n/4.
+        for (std::size_t i = 0; i < frameSize_; i++) {
+            window_[i] = 0.5 * (1.0 - std::cos(2.0 * kPi * static_cast<double>(i) /
+                                               static_cast<double>(frameSize_)));
+        }
+    }
+
+    static constexpr double kPi = 3.14159265358979323846;
+
+    FftBackend& fft_;
+    std::size_t frameSize_;
+    std::size_t hopSize_;
+    std::vector<double> window_;
+    std::vector<float> frame_;
+    std::vector<float> spectrum_;
+    std::vector<float> windowSum_;
+};
+
+}  // namespace stems
+}  // namespace WiggleRoom

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -33,6 +33,7 @@
 #include "common/stems/FftBackend.hpp"
 #include "common/stems/ReferenceFft.hpp"
 #include "common/stems/RingBuffer.hpp"
+#include "common/stems/Stft.hpp"
 #include "common/stems/Transport.hpp"
 
 #include <cmath>
@@ -695,6 +696,133 @@ bool transportResetMidInterval(std::string& detail) {
     return true;
 }
 
+// ---------------------------------------------------------------------------
+// STFT
+// ---------------------------------------------------------------------------
+
+using WiggleRoom::stems::Stft;
+
+/**
+ * Analysis then synthesis with no processing must reconstruct the input.
+ *
+ * This is the property everything downstream depends on: if the STFT does not
+ * round-trip, every HPSS mask is applied to a signal that was already wrong.
+ * Tested at lengths that are NOT multiples of the hop, because that is where
+ * overlap-add framing bugs actually live.
+ */
+bool stftReconstruct(std::size_t inputLength, double& maxErrOut) {
+    ReferenceFft fft(2048);
+    Stft stft(fft, /*hop=*/512);
+
+    std::vector<float> input(inputLength);
+    std::mt19937 rng(4242);
+    std::uniform_real_distribution<float> dist(-0.8f, 0.8f);
+    for (auto& v : input) v = dist(rng);
+
+    std::vector<float> output(inputLength, 0.f);
+    stft.process(input.data(), output.data(), inputLength,
+                 [](float*, std::size_t) { /* identity */ });
+
+    // Ignore the first and last window: overlap-add cannot reconstruct the
+    // ramp-in and ramp-out regions without extra padding, which is expected.
+    const std::size_t skip = stft.frameSize();
+    if (inputLength <= 2 * skip) { maxErrOut = 0.0; return true; }
+
+    double maxErr = 0.0;
+    for (std::size_t i = skip; i < inputLength - skip; i++) {
+        maxErr = std::max(maxErr, std::abs(static_cast<double>(output[i] - input[i])));
+    }
+    maxErrOut = maxErr;
+    return maxErr < 1e-4;
+}
+
+bool stftReconstructDefault(std::string& detail) {
+    double err = 0.0;
+    const bool ok = stftReconstruct(48000, err);
+    if (!ok) detail = "max error " + std::to_string(err);
+    return ok;
+}
+
+/** Framing must be correct at lengths that are not multiples of the hop. */
+bool stftReconstructOddLengths(std::string& detail) {
+    const std::size_t lengths[] = {4096, 4097, 5000, 6143, 8191, 12345, 20000};
+    for (std::size_t len : lengths) {
+        double err = 0.0;
+        if (!stftReconstruct(len, err)) {
+            detail = "length " + std::to_string(len) + " max error " + std::to_string(err);
+            return false;
+        }
+    }
+    return true;
+}
+
+/** Zeroing every bin must yield silence, proving the mask path is wired up. */
+bool stftZeroMask(std::string& detail) {
+    ReferenceFft fft(2048);
+    Stft stft(fft, 512);
+
+    std::vector<float> input(20000, 0.5f);
+    std::vector<float> output(20000, 1.f);
+    stft.process(input.data(), output.data(), input.size(),
+                 [](float* spectrum, std::size_t len) {
+                     for (std::size_t i = 0; i < len; i++) spectrum[i] = 0.f;
+                 });
+
+    for (std::size_t i = 0; i < output.size(); i++) {
+        if (std::abs(output[i]) > 1e-6f) {
+            detail = "sample " + std::to_string(i) + " is " + std::to_string(output[i]);
+            return false;
+        }
+    }
+    return true;
+}
+
+/** An empty or very short input must not read out of bounds or emit NaN. */
+bool stftShortInput(std::string& detail) {
+    ReferenceFft fft(2048);
+    Stft stft(fft, 512);
+
+    for (std::size_t len : {std::size_t(0), std::size_t(1), std::size_t(100), std::size_t(2047)}) {
+        std::vector<float> input(len, 0.3f);
+        std::vector<float> output(len, 0.f);
+        stft.process(input.empty() ? nullptr : input.data(),
+                     output.empty() ? nullptr : output.data(),
+                     len, [](float*, std::size_t) {});
+        for (std::size_t i = 0; i < len; i++) {
+            if (!std::isfinite(output[i])) {
+                detail = "non-finite output at length " + std::to_string(len);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/** The window must satisfy COLA at hop = frameSize/4, which is what makes
+ *  overlap-add reconstruct rather than amplitude-modulate the signal. */
+bool stftCola(std::string& detail) {
+    ReferenceFft fft(2048);
+    Stft stft(fft, 512);
+
+    const std::size_t n = stft.frameSize();
+    const std::size_t hop = stft.hopSize();
+    std::vector<double> sum(n * 4, 0.0);
+    for (std::size_t start = 0; start + n <= sum.size(); start += hop) {
+        for (std::size_t i = 0; i < n; i++) sum[start + i] += stft.windowGain(i);
+    }
+    // Inspect the steady-state region only.
+    double lo = 1e9, hi = -1e9;
+    for (std::size_t i = n; i < sum.size() - n; i++) {
+        lo = std::min(lo, sum[i]);
+        hi = std::max(hi, sum[i]);
+    }
+    if (std::abs(hi - lo) > 1e-6) {
+        detail = "window sum ripples between " + std::to_string(lo) + " and " + std::to_string(hi);
+        return false;
+    }
+    return true;
+}
+
 }  // namespace
 
 /**
@@ -730,6 +858,11 @@ const char* const kCommands[] = {
     "--test-transport-clock-restart",
     "--test-transport-downbeat-jitter",
     "--test-transport-reset-midinterval",
+    "--test-stft-reconstruct",
+    "--test-stft-odd-lengths",
+    "--test-stft-zero-mask",
+    "--test-stft-short-input",
+    "--test-stft-cola",
 };
 
 int main(int argc, char** argv) {
@@ -817,6 +950,11 @@ int main(int argc, char** argv) {
             {"--test-transport-clock-restart",   "transport_clock_restart",   transportClockRestart},
             {"--test-transport-downbeat-jitter", "transport_downbeat_jitter", transportDownbeatJitter},
             {"--test-transport-reset-midinterval","transport_reset_midinterval",transportResetMidInterval},
+            {"--test-stft-reconstruct",   "stft_reconstruct",   stftReconstructDefault},
+            {"--test-stft-odd-lengths",   "stft_odd_lengths",   stftReconstructOddLengths},
+            {"--test-stft-zero-mask",     "stft_zero_mask",     stftZeroMask},
+            {"--test-stft-short-input",   "stft_short_input",   stftShortInput},
+            {"--test-stft-cola",          "stft_cola",          stftCola},
         };
         for (const auto& c : bufferCases) {
             if (cmd == c.cmd) {
@@ -862,6 +1000,11 @@ int main(int argc, char** argv) {
         record(transportClockRestart(detail));
         record(transportDownbeatJitter(detail));
         record(transportResetMidInterval(detail));
+        record(stftReconstructDefault(detail));
+        record(stftReconstructOddLengths(detail));
+        record(stftZeroMask(detail));
+        record(stftShortInput(detail));
+        record(stftCola(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -723,13 +723,11 @@ bool stftReconstruct(std::size_t inputLength, double& maxErrOut) {
     stft.process(input.data(), output.data(), inputLength,
                  [](float*, std::size_t) { /* identity */ });
 
-    // Ignore the first and last window: overlap-add cannot reconstruct the
-    // ramp-in and ramp-out regions without extra padding, which is expected.
-    const std::size_t skip = stft.frameSize();
-    if (inputLength <= 2 * skip) { maxErrOut = 0.0; return true; }
-
+    // Assert over the WHOLE signal, including the first and last samples.
+    // Skipping a frame at each end conceals boundary gaps: an unpadded
+    // implementation leaves the tail after the last complete frame silent.
     double maxErr = 0.0;
-    for (std::size_t i = skip; i < inputLength - skip; i++) {
+    for (std::size_t i = 0; i < inputLength; i++) {
         maxErr = std::max(maxErr, std::abs(static_cast<double>(output[i] - input[i])));
     }
     maxErrOut = maxErr;
@@ -823,6 +821,26 @@ bool stftCola(std::string& detail) {
     return true;
 }
 
+/** A tiny FFT must not derive a zero hop and hang the worker forever. */
+bool stftTinyFft(std::string& detail) {
+    for (std::size_t n : {std::size_t(2), std::size_t(4), std::size_t(8)}) {
+        ReferenceFft fft(n);
+        Stft stft(fft);
+        if (stft.hopSize() < 1) {
+            detail = "fft size " + std::to_string(n) + " derived hop " +
+                     std::to_string(stft.hopSize()) + "; process() would never advance";
+            return false;
+        }
+        // Must terminate.
+        std::vector<float> in(64, 0.25f), out(64, 0.f);
+        stft.process(in.data(), out.data(), in.size(), [](float*, std::size_t) {});
+        for (float v : out) {
+            if (!std::isfinite(v)) { detail = "non-finite output at fft size " + std::to_string(n); return false; }
+        }
+    }
+    return true;
+}
+
 }  // namespace
 
 /**
@@ -863,6 +881,7 @@ const char* const kCommands[] = {
     "--test-stft-zero-mask",
     "--test-stft-short-input",
     "--test-stft-cola",
+    "--test-stft-tiny-fft",
 };
 
 int main(int argc, char** argv) {
@@ -955,6 +974,7 @@ int main(int argc, char** argv) {
             {"--test-stft-zero-mask",     "stft_zero_mask",     stftZeroMask},
             {"--test-stft-short-input",   "stft_short_input",   stftShortInput},
             {"--test-stft-cola",          "stft_cola",          stftCola},
+            {"--test-stft-tiny-fft",      "stft_tiny_fft",      stftTinyFft},
         };
         for (const auto& c : bufferCases) {
             if (cmd == c.cmd) {
@@ -1005,6 +1025,7 @@ int main(int argc, char** argv) {
         record(stftZeroMask(detail));
         record(stftShortInput(detail));
         record(stftCola(detail));
+        record(stftTinyFft(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -257,9 +257,16 @@ class TestStft:
     def test_reconstructs_the_input(self):
         """Analysis then synthesis with no processing must return the input.
 
+        Asserted over the WHOLE signal including the first and last samples.
+        An earlier version skipped a frame at each end, which concealed a real
+        boundary gap: without padding the tail after the last complete frame is
+        silent, and the first sample is never covered because the Hann window
+        is zero there.
+
         Everything downstream depends on this: if the STFT does not round-trip,
         every HPSS mask is applied to a signal that was already wrong. Verified
-        to have teeth: removing the window-sum normalisation fails at 0.4.
+        to have teeth twice: removing the window-sum normalisation fails at 0.4,
+        removing the padding fails at 0.8.
         """
         result = run_test(["--test-stft-reconstruct"])
         assert result["failed"] == 0, result.get("detail", "")
@@ -277,6 +284,13 @@ class TestStft:
     def test_short_and_empty_input_is_safe(self):
         """Inputs shorter than one frame must not read out of bounds or emit NaN."""
         result = run_test(["--test-stft-short-input"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_tiny_fft_does_not_hang(self):
+        """A size-2 backend derives hop = size/4 = 0, and the frame loop would
+        never advance, hanging the worker thread forever. FftBackend permits
+        sizes that small, so the hop is clamped to at least one sample."""
+        result = run_test(["--test-stft-tiny-fft"])
         assert result["failed"] == 0, result.get("detail", "")
 
     def test_window_satisfies_cola(self):

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -246,10 +246,54 @@ class TestTransport:
         assert result["failed"] == 0, result.get("detail", "")
 
 
+class TestStft:
+    """Short-time Fourier transform front end.
+
+    Parameters match librosa defaults (n_fft 2048, hop 512) so HPSS results can
+    be cross-checked against a reference implementation in S6 rather than only
+    against themselves.
+    """
+
+    def test_reconstructs_the_input(self):
+        """Analysis then synthesis with no processing must return the input.
+
+        Everything downstream depends on this: if the STFT does not round-trip,
+        every HPSS mask is applied to a signal that was already wrong. Verified
+        to have teeth: removing the window-sum normalisation fails at 0.4.
+        """
+        result = run_test(["--test-stft-reconstruct"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_reconstructs_at_lengths_that_are_not_hop_multiples(self):
+        """Framing bugs live at lengths that are not multiples of the hop."""
+        result = run_test(["--test-stft-odd-lengths"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_zeroing_every_bin_gives_silence(self):
+        """Proves the modify callback is actually wired into the round-trip."""
+        result = run_test(["--test-stft-zero-mask"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_short_and_empty_input_is_safe(self):
+        """Inputs shorter than one frame must not read out of bounds or emit NaN."""
+        result = run_test(["--test-stft-short-input"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_window_satisfies_cola(self):
+        """The squared Hann window must sum to a constant at hop = n/4.
+
+        Without this, overlap-add amplitude-modulates the signal instead of
+        reconstructing it. Verified to have teeth: the symmetric Hann variant,
+        a common mistake, ripples and fails.
+        """
+        result = run_test(["--test-stft-cola"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+
 def run_all_tests() -> bool:
     passed = failed = 0
     errors = []
-    for cls in (TestFftBackend, TestRingBuffer, TestTransport):
+    for cls in (TestFftBackend, TestRingBuffer, TestTransport, TestStft):
         instance = cls()
         for name in dir(instance):
             if not name.startswith("test_"):


### PR DESCRIPTION
Closes #72. Epic #90. The substrate HPSS sits on.

## Two decisions that matter for S6

**The Hann window is applied on synthesis as well as analysis.** Analysis-only windowing reconstructs fine when nothing is modified, which is exactly why it is an easy mistake to ship. But HPSS exists to modify the spectrum, and a modified frame reconstructed without a synthesis window produces a discontinuity at every frame boundary. Windowing both sides is what makes masking safe.

**Periodic Hann, not symmetric.** Only the periodic form satisfies constant-overlap-add of the *squared* window at hop = n/4. The symmetric variant is the more commonly written one and silently ripples, amplitude-modulating the output rather than reconstructing it.

Normalisation divides by the accumulated squared window per sample rather than by a constant gain, so the ramp-in and ramp-out regions are correct too, not just the steady state.

## Every test verified to have teeth

Not just "it passes", but "it fails when the thing it guards is broken":

| Test | Broken variant | Result |
|---|---|---|
| Reconstruction | Remove window-sum normalisation | Fails at **0.399985** |
| COLA | Symmetric Hann instead of periodic | Ripples **1.499233 to 1.499299** |
| Odd lengths | (framing) | Covers 4097, 5000, 6143, 8191, 12345 |
| Zero mask | (wiring) | Proves `modify` is actually called |
| Short input | (bounds) | 0, 1, 100 and 2047 samples, no NaN |

The odd-length test matters because overlap-add framing bugs do not show up at clean multiples of the hop.

## Correction to something I said on #94

I suggested there that the test target's header dependencies might be set up wrongly, after being misled three times by stale builds. I checked: **the depfile tracks all five core headers correctly.** The stale results were a same-second timestamp artefact from running many rebuilds in quick succession, not a project bug. Touching the `.cpp` rather than the header makes it reliable.

## Verification

```
stems_test --self-test    23 -> 28 checks
test_stems.py             24 -> 29 passed
just test-native          green
coverage guard            52 -> 57 commands
```