### PR TITLE
S6: Tier 0 HPSS separation into four disjoint layers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,9 @@ jobs:
           sudo apt-get install -y faust
           faust --version
 
+      - name: Install Python test dependencies
+        run: pip install numpy scipy
+
       - name: "3.1 Test Faust DSP compilation"
         run: just test-faust
 

--- a/Justfile
+++ b/Justfile
@@ -317,6 +317,8 @@ test-native:
     python3 test/test_euclogic.py
     echo "== test_stems.py =="
     python3 test/test_stems.py
+    echo "== test_hpss_reference.py =="
+    python3 test/test_hpss_reference.py
     echo "== test_native_coverage.py =="
     python3 test/test_native_coverage.py
     echo "All native tests passed."

--- a/src/common/stems/Hpss.hpp
+++ b/src/common/stems/Hpss.hpp
@@ -75,10 +75,17 @@ public:
         for (int L = 0; L < kNumLayers; L++) out.layer[L].assign(length, 0.f);
         if (!input || length == 0) return;
 
+        // Detect sub-frame input BEFORE analysis. Stft pads a whole frame on
+        // both sides, so analyse() always yields frames and a frames_ == 0
+        // check here would be unreachable; short recordings would be smeared
+        // spectrally across all four layers instead of passing through.
+        if (length < fft_.size()) {
+            std::copy(input, input + length, out.layer[(int)StemLayer::Residual].begin());
+            return;
+        }
+
         analyse(input, length);
         if (frames_ == 0) {
-            // Too short for a single frame. Route everything to Residual so the
-            // layers still sum to the source rather than silently dropping it.
             std::copy(input, input + length, out.layer[(int)StemLayer::Residual].begin());
             return;
         }
@@ -88,6 +95,13 @@ public:
         for (int L = 0; L < kNumLayers; L++) {
             synthesise(input, length, L, out.layer[L]);
         }
+    }
+
+    /** Expose the share computation so its algebra can be tested directly. */
+    void debugShares(float h, float p, float& harm, float& perc, float& res) const {
+        harm = shareOf(h, p);
+        perc = shareOf(p, h);
+        res  = std::max(0.f, 1.f - harm - perc);
     }
 
     // --- Introspection for cross-validation against a reference implementation.
@@ -149,14 +163,31 @@ private:
         lowSplitBin_ = std::min(lowSplitBin_, bins);
     }
 
+    /**
+     * scipy.ndimage 'reflect' index mapping: (d c b a | a b c d | d c b a).
+     *
+     * Dropping out-of-range neighbours instead would leave edge windows shorter
+     * than the kernel, and sometimes even-length, so the first and last
+     * kernel/2 frames would be filtered differently from the interior. With the
+     * default kernel that is 15 frames at each end, which is exactly where loop
+     * boundaries live.
+     */
+    static std::size_t reflectIndex(long long i, long long n) {
+        if (n <= 1) return 0;
+        const long long period = 2 * n;
+        long long m = ((i % period) + period) % period;   // wrap into [0, 2n)
+        if (m >= n) m = period - 1 - m;                   // fold the upper half
+        return static_cast<std::size_t>(m);
+    }
+
     float medianAlongTime(std::size_t f, std::size_t b, std::size_t bins,
                           std::vector<float>& scratch) const {
         const int half = kernel_ / 2;
         int count = 0;
         for (int k = -half; k <= half; k++) {
-            const long long idx = static_cast<long long>(f) + k;
-            if (idx < 0 || idx >= static_cast<long long>(frames_)) continue;
-            scratch[count++] = magnitude_[static_cast<std::size_t>(idx) * bins + b];
+            const std::size_t idx =
+                reflectIndex(static_cast<long long>(f) + k, static_cast<long long>(frames_));
+            scratch[count++] = magnitude_[idx * bins + b];
         }
         return medianOf(scratch, count);
     }
@@ -166,9 +197,9 @@ private:
         const int half = kernel_ / 2;
         int count = 0;
         for (int k = -half; k <= half; k++) {
-            const long long idx = static_cast<long long>(b) + k;
-            if (idx < 0 || idx >= static_cast<long long>(bins)) continue;
-            scratch[count++] = magnitude_[f * bins + static_cast<std::size_t>(idx)];
+            const std::size_t idx =
+                reflectIndex(static_cast<long long>(b) + k, static_cast<long long>(bins));
+            scratch[count++] = magnitude_[f * bins + idx];
         }
         return medianOf(scratch, count);
     }
@@ -218,9 +249,7 @@ private:
 
         const float h = harmMedian_[f * bins + b];
         const float p = percMedian_[f * bins + b];
-        const float hp = std::pow(h, power_);
-        const float pp = std::pow(p, power_);
-        const float denom = hp + pp;
+        const float denom = std::pow(h, power_) + std::pow(p, power_);
 
         if (!(denom > 1e-20f)) {
             // No energy to attribute. Give it to Residual so the masks still
@@ -228,12 +257,12 @@ private:
             return (layer == (int)StemLayer::Residual) ? 1.f : 0.f;
         }
 
-        // Margin-weighted soft masks. At margin 1 these reduce to hp/denom and
-        // pp/denom and sum to exactly 1. Above 1, both are attenuated where the
-        // two medians are comparable, and what neither claims is Residual. That
-        // is what stops the fourth layer being permanently silent.
-        const float harmShare = hp / (hp + margin_ * pp);
-        const float percShare = pp / (pp + margin_ * hp);
+        // Margin-weighted soft masks. The margin scales the COMPETING median
+        // before the exponent, matching the reference: h^p / (h^p + (m*p)^p).
+        // Applying it afterwards gives a weaker effective margin than
+        // configured, and correspondingly less residual.
+        const float harmShare = shareOf(h, p);
+        const float percShare = shareOf(p, h);
 
         switch (static_cast<StemLayer>(layer)) {
             case StemLayer::Percussive: return percShare;
@@ -244,6 +273,14 @@ private:
                 return std::max(0.f, 1.f - harmShare - percShare);
             default:                    return 0.f;
         }
+    }
+
+    /** mine^power / (mine^power + (margin * other)^power). */
+    float shareOf(float mine, float other) const {
+        const float a = std::pow(mine, power_);
+        const float b = std::pow(margin_ * other, power_);
+        const float denom = a + b;
+        return (denom > 1e-20f) ? (a / denom) : 0.f;
     }
 
     FftBackend& fft_;

--- a/src/common/stems/Hpss.hpp
+++ b/src/common/stems/Hpss.hpp
@@ -1,0 +1,243 @@
+#pragma once
+/******************************************************************************
+ * Hpss - Tier 0 separation for Stems
+ *
+ * Harmonic/percussive separation by median filtering on the magnitude
+ * spectrogram (Fitzgerald, DAFx-10; margin extension Driedger, Muller and
+ * Disch, 2014), combined with a low band split, producing four layers.
+ *
+ * Why this rather than a neural model: it is cheap, deterministic, needs no
+ * model files and adds no dependency. The instrument needs material that
+ * differs from itself, not correctly labelled instruments, so four musically
+ * distinct layers are sufficient for the MVP. That removes ML deployment from
+ * the critical path entirely; Tier 1 can be added later behind the same
+ * interface.
+ *
+ * Parameters follow librosa's defaults (kernel 31, power 2.0, margin 1.0, soft
+ * Wiener-style masks) so results can be cross-checked against a reference
+ * implementation.
+ *
+ * The four layers are DISJOINT. Masks are applied in order, each excluding what
+ * earlier layers claimed, so summing all four at unity reconstructs the source.
+ * Defining Harmonic without excluding the Low band would make them overlap and
+ * the default all-faders-at-unity state would double-count bass.
+ *
+ * Runs on the worker thread over a whole recorded buffer. Not RT-safe.
+ ******************************************************************************/
+
+#include "FftBackend.hpp"
+#include "Stft.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace WiggleRoom {
+namespace stems {
+
+enum class StemLayer { Low = 0, Percussive = 1, Harmonic = 2, Residual = 3 };
+
+class Hpss {
+public:
+    static constexpr int kNumLayers = 4;
+
+    struct Result {
+        std::vector<float> layer[kNumLayers];
+    };
+
+    explicit Hpss(FftBackend& fft) : fft_(fft), stft_(fft) {}
+
+    /** Median filter length in frames/bins. librosa's default is 31. */
+    void setKernelSize(int kernel) { kernel_ = std::max(3, kernel | 1); }
+
+    /** Mask exponent. librosa's default is 2.0. */
+    void setPower(float power) { power_ = std::max(0.f, power); }
+
+    /** Split frequency below which content is routed to the Low layer. */
+    void setLowSplitHz(float hz) { lowSplitHz_ = std::max(0.f, hz); }
+
+    /**
+     * Separate @p input into four disjoint layers.
+     * Each output layer is resized to @p length.
+     */
+    void separate(const float* input, std::size_t length, int sampleRate, Result& out) {
+        for (int L = 0; L < kNumLayers; L++) out.layer[L].assign(length, 0.f);
+        if (!input || length == 0) return;
+
+        analyse(input, length);
+        if (frames_ == 0) {
+            // Too short for a single frame. Route everything to Residual so the
+            // layers still sum to the source rather than silently dropping it.
+            std::copy(input, input + length, out.layer[(int)StemLayer::Residual].begin());
+            return;
+        }
+
+        buildMasks(sampleRate);
+
+        for (int L = 0; L < kNumLayers; L++) {
+            synthesise(input, length, L, out.layer[L]);
+        }
+    }
+
+    // --- Introspection for cross-validation against a reference implementation.
+    // Exposed so tests can median-filter the SAME magnitudes with scipy and
+    // compare, which isolates the median filter from STFT differences.
+    std::size_t debugFrames() const { return frames_; }
+    std::size_t debugBins() const { return fft_.numBins(); }
+    const std::vector<float>& debugMagnitude() const { return magnitude_; }
+    const std::vector<float>& debugHarmonicMedian() const { return harmMedian_; }
+    const std::vector<float>& debugPercussiveMedian() const { return percMedian_; }
+    int debugKernel() const { return kernel_; }
+
+private:
+    /** Collect the magnitude spectrogram so masks can be computed across frames. */
+    void analyse(const float* input, std::size_t length) {
+        const std::size_t bins = fft_.numBins();
+        magnitude_.clear();
+        frames_ = 0;
+
+        std::vector<float> scratchOut(length, 0.f);
+        stft_.process(input, scratchOut.data(), length,
+                      [&](float* spectrum, std::size_t) {
+                          magnitude_.resize((frames_ + 1) * bins);
+                          for (std::size_t b = 0; b < bins; b++) {
+                              const float re = spectrum[2 * b];
+                              const float im = spectrum[2 * b + 1];
+                              magnitude_[frames_ * bins + b] = std::sqrt(re * re + im * im);
+                          }
+                          frames_++;
+                      });
+    }
+
+    void buildMasks(int sampleRate) {
+        const std::size_t bins = fft_.numBins();
+        harmMedian_.assign(frames_ * bins, 0.f);
+        percMedian_.assign(frames_ * bins, 0.f);
+
+        // Median across TIME enhances sustained content (harmonic).
+        std::vector<float> window(kernel_);
+        for (std::size_t b = 0; b < bins; b++) {
+            for (std::size_t f = 0; f < frames_; f++) {
+                harmMedian_[f * bins + b] = medianAlongTime(f, b, bins, window);
+            }
+        }
+        // Median across FREQUENCY enhances transient content (percussive).
+        for (std::size_t f = 0; f < frames_; f++) {
+            for (std::size_t b = 0; b < bins; b++) {
+                percMedian_[f * bins + b] = medianAlongFreq(f, b, bins, window);
+            }
+        }
+
+        // Bin index of the low split.
+        const double binHz = static_cast<double>(sampleRate) / static_cast<double>(fft_.size());
+        lowSplitBin_ = static_cast<std::size_t>(std::lround(lowSplitHz_ / binHz));
+        lowSplitBin_ = std::min(lowSplitBin_, bins);
+    }
+
+    float medianAlongTime(std::size_t f, std::size_t b, std::size_t bins,
+                          std::vector<float>& scratch) const {
+        const int half = kernel_ / 2;
+        int count = 0;
+        for (int k = -half; k <= half; k++) {
+            const long long idx = static_cast<long long>(f) + k;
+            if (idx < 0 || idx >= static_cast<long long>(frames_)) continue;
+            scratch[count++] = magnitude_[static_cast<std::size_t>(idx) * bins + b];
+        }
+        return medianOf(scratch, count);
+    }
+
+    float medianAlongFreq(std::size_t f, std::size_t b, std::size_t bins,
+                          std::vector<float>& scratch) const {
+        const int half = kernel_ / 2;
+        int count = 0;
+        for (int k = -half; k <= half; k++) {
+            const long long idx = static_cast<long long>(b) + k;
+            if (idx < 0 || idx >= static_cast<long long>(bins)) continue;
+            scratch[count++] = magnitude_[f * bins + static_cast<std::size_t>(idx)];
+        }
+        return medianOf(scratch, count);
+    }
+
+    static float medianOf(std::vector<float>& v, int count) {
+        if (count == 0) return 0.f;
+        std::nth_element(v.begin(), v.begin() + count / 2, v.begin() + count);
+        return v[count / 2];
+    }
+
+    /**
+     * Re-run the STFT applying this layer's mask.
+     *
+     * Masks are computed here rather than cached so each layer's weights are
+     * derived from the same medians, which is what keeps them summing to one.
+     */
+    void synthesise(const float* input, std::size_t length, int layer,
+                    std::vector<float>& out) {
+        const std::size_t bins = fft_.numBins();
+        std::size_t frame = 0;
+
+        stft_.process(input, out.data(), length, [&](float* spectrum, std::size_t) {
+            if (frame >= frames_) return;
+            for (std::size_t b = 0; b < bins; b++) {
+                const float gain = maskFor(layer, frame, b, bins);
+                spectrum[2 * b]     *= gain;
+                spectrum[2 * b + 1] *= gain;
+            }
+            frame++;
+        });
+    }
+
+    /**
+     * Disjoint masks summing to 1 per bin.
+     *
+     *   Low         : everything below the split
+     *   Percussive  : soft percussive share of what remains
+     *   Harmonic    : soft harmonic share of what remains
+     *   Residual    : whatever neither claims
+     */
+    float maskFor(int layer, std::size_t f, std::size_t b, std::size_t bins) const {
+        const bool isLow = b < lowSplitBin_;
+        if (isLow) {
+            return (layer == (int)StemLayer::Low) ? 1.f : 0.f;
+        }
+        if (layer == (int)StemLayer::Low) return 0.f;
+
+        const float h = harmMedian_[f * bins + b];
+        const float p = percMedian_[f * bins + b];
+        const float hp = std::pow(h, power_);
+        const float pp = std::pow(p, power_);
+        const float denom = hp + pp;
+
+        if (!(denom > 1e-20f)) {
+            // No energy to attribute. Give it to Residual so the masks still
+            // sum to one and the layers remain disjoint.
+            return (layer == (int)StemLayer::Residual) ? 1.f : 0.f;
+        }
+
+        const float harmShare = hp / denom;
+        const float percShare = pp / denom;
+
+        switch (static_cast<StemLayer>(layer)) {
+            case StemLayer::Percussive: return percShare;
+            case StemLayer::Harmonic:   return harmShare;
+            case StemLayer::Residual:   return 0.f;  // shares already total 1
+            default:                    return 0.f;
+        }
+    }
+
+    FftBackend& fft_;
+    Stft stft_;
+
+    int kernel_ = 31;
+    float power_ = 2.f;
+    float lowSplitHz_ = 200.f;
+    std::size_t lowSplitBin_ = 0;
+
+    std::size_t frames_ = 0;
+    std::vector<float> magnitude_;
+    std::vector<float> harmMedian_;
+    std::vector<float> percMedian_;
+};
+
+}  // namespace stems
+}  // namespace WiggleRoom

--- a/src/common/stems/Hpss.hpp
+++ b/src/common/stems/Hpss.hpp
@@ -54,6 +54,16 @@ public:
     /** Mask exponent. librosa's default is 2.0. */
     void setPower(float power) { power_ = std::max(0.f, power); }
 
+    /**
+     * Separation margin. At 1.0 the harmonic and percussive shares sum to
+     * exactly 1 and nothing is left over, which is librosa's behaviour but
+     * leaves our fourth layer permanently silent. Above 1.0 each share is
+     * attenuated where the two are comparable, and the unclaimed remainder
+     * becomes Residual. This is the Driedger/Muller/Disch margin idea in soft
+     * form.
+     */
+    void setMargin(float margin) { margin_ = std::max(1.f, margin); }
+
     /** Split frequency below which content is routed to the Low layer. */
     void setLowSplitHz(float hz) { lowSplitHz_ = std::max(0.f, hz); }
 
@@ -130,8 +140,12 @@ private:
         }
 
         // Bin index of the low split.
+        // Ceiling, not rounding. lowSplitBin_ is the first bin AT OR ABOVE the
+        // split, so `b < lowSplitBin_` keeps every bin whose centre is below it.
+        // Rounding excluded such bins: at 44.1 kHz with a 2048-point FFT and a
+        // 200 Hz split it gave bin 9, whose centre is about 193.8 Hz.
         const double binHz = static_cast<double>(sampleRate) / static_cast<double>(fft_.size());
-        lowSplitBin_ = static_cast<std::size_t>(std::lround(lowSplitHz_ / binHz));
+        lowSplitBin_ = static_cast<std::size_t>(std::ceil(lowSplitHz_ / binHz));
         lowSplitBin_ = std::min(lowSplitBin_, bins);
     }
 
@@ -214,13 +228,20 @@ private:
             return (layer == (int)StemLayer::Residual) ? 1.f : 0.f;
         }
 
-        const float harmShare = hp / denom;
-        const float percShare = pp / denom;
+        // Margin-weighted soft masks. At margin 1 these reduce to hp/denom and
+        // pp/denom and sum to exactly 1. Above 1, both are attenuated where the
+        // two medians are comparable, and what neither claims is Residual. That
+        // is what stops the fourth layer being permanently silent.
+        const float harmShare = hp / (hp + margin_ * pp);
+        const float percShare = pp / (pp + margin_ * hp);
 
         switch (static_cast<StemLayer>(layer)) {
             case StemLayer::Percussive: return percShare;
             case StemLayer::Harmonic:   return harmShare;
-            case StemLayer::Residual:   return 0.f;  // shares already total 1
+            case StemLayer::Residual:
+                // Whatever the two shares leave unclaimed. Clamped because
+                // rounding can push the sum a hair over 1.
+                return std::max(0.f, 1.f - harmShare - percShare);
             default:                    return 0.f;
         }
     }
@@ -231,6 +252,8 @@ private:
     int kernel_ = 31;
     float power_ = 2.f;
     float lowSplitHz_ = 200.f;
+    // Above 1 so Residual carries the ambiguous energy rather than being silent.
+    float margin_ = 2.f;
     std::size_t lowSplitBin_ = 0;
 
     std::size_t frames_ = 0;

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -1145,6 +1145,72 @@ bool hpssLowSplitBoundary(std::string& detail) {
     return true;
 }
 
+/** The margin must scale the competing median BEFORE the soft-mask exponent.
+ *
+ *  The reference computes h^p / (h^p + (margin*p)^p). Applying the margin
+ *  afterwards, as h^p / (h^p + margin*p^p), gives a weaker effective margin
+ *  than configured and leaves less residual than the algorithm specifies.
+ */
+bool hpssMarginBeforeExponent(std::string& detail) {
+    ReferenceFft fft(256);
+    Hpss hpss(fft);
+    hpss.setPower(2.f);
+    hpss.setMargin(2.f);
+
+    // Equal medians: the maximally ambiguous case, where the margin bites most.
+    float harm = 0.f, perc = 0.f, res = 0.f;
+    hpss.debugShares(1.f, 1.f, harm, perc, res);
+
+    // h^2 / (h^2 + (2p)^2) = 1 / (1 + 4) = 0.2
+    const float expected = 1.f / 5.f;
+    if (std::abs(harm - expected) > 1e-4f) {
+        detail = "equal medians gave share " + std::to_string(harm) +
+                 ", expected " + std::to_string(expected) +
+                 " (margin applied after the exponent gives 0.333)";
+        return false;
+    }
+    if (std::abs(res - (1.f - 2.f * expected)) > 1e-4f) {
+        detail = "residual " + std::to_string(res) + " inconsistent with shares";
+        return false;
+    }
+    return true;
+}
+
+/** Input shorter than one FFT frame must be copied intact to Residual.
+ *
+ *  Stft pads by a whole frame on both sides, so analyse() always produces
+ *  frames and the sub-frame branch was unreachable; short recordings were
+ *  being spectrally smeared across all four layers instead.
+ */
+bool hpssSubFrameInput(std::string& detail) {
+    const std::size_t n = 500;          // well under a 2048 frame
+    std::vector<float> in(n);
+    for (std::size_t i = 0; i < n; i++) in[i] = 0.25f + 0.01f * static_cast<float>(i % 7);
+
+    ReferenceFft fft(2048);
+    Hpss hpss(fft);
+    Hpss::Result out;
+    hpss.separate(in.data(), n, 48000, out);
+
+    for (std::size_t i = 0; i < n; i++) {
+        if (std::abs(out.layer[(int)StemLayer::Residual][i] - in[i]) > 1e-6f) {
+            detail = "residual sample " + std::to_string(i) + " is " +
+                     std::to_string(out.layer[(int)StemLayer::Residual][i]) +
+                     ", expected " + std::to_string(in[i]);
+            return false;
+        }
+    }
+    for (int L : {(int)StemLayer::Low, (int)StemLayer::Percussive, (int)StemLayer::Harmonic}) {
+        for (std::size_t i = 0; i < n; i++) {
+            if (std::abs(out.layer[L][i]) > 1e-6f) {
+                detail = "layer " + std::to_string(L) + " should be silent for sub-frame input";
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 }  // namespace
 
 /**
@@ -1192,6 +1258,8 @@ const char* const kCommands[] = {
     "--test-hpss-degenerate",
     "--test-hpss-residual",
     "--test-hpss-low-split-boundary",
+    "--test-hpss-margin",
+    "--test-hpss-subframe",
 };
 
 int main(int argc, char** argv) {
@@ -1293,6 +1361,8 @@ int main(int argc, char** argv) {
             {"--test-hpss-degenerate",    "hpss_degenerate",    hpssDegenerate},
             {"--test-hpss-residual",      "hpss_residual",      hpssResidualPopulated},
             {"--test-hpss-low-split-boundary","hpss_low_split_boundary",hpssLowSplitBoundary},
+            {"--test-hpss-margin",        "hpss_margin",        hpssMarginBeforeExponent},
+            {"--test-hpss-subframe",      "hpss_subframe",      hpssSubFrameInput},
         };
         for (const auto& c : bufferCases) {
             if (cmd == c.cmd) {
@@ -1350,6 +1420,8 @@ int main(int argc, char** argv) {
         record(hpssDegenerate(detail));
         record(hpssResidualPopulated(detail));
         record(hpssLowSplitBoundary(detail));
+        record(hpssMarginBeforeExponent(detail));
+        record(hpssSubFrameInput(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -33,6 +33,7 @@
 #include "common/stems/FftBackend.hpp"
 #include "common/stems/ReferenceFft.hpp"
 #include "common/stems/RingBuffer.hpp"
+#include "common/stems/Hpss.hpp"
 #include "common/stems/Stft.hpp"
 #include "common/stems/Transport.hpp"
 
@@ -841,6 +842,243 @@ bool stftTinyFft(std::string& detail) {
     return true;
 }
 
+// ---------------------------------------------------------------------------
+// HPSS (Tier 0 separation)
+// ---------------------------------------------------------------------------
+
+using WiggleRoom::stems::Hpss;
+using WiggleRoom::stems::StemLayer;
+
+namespace {
+/** Energy of a signal. */
+double energy(const std::vector<float>& x) {
+    double e = 0.0;
+    for (float v : x) e += static_cast<double>(v) * v;
+    return e;
+}
+
+/** A click train: broadband transients, sparse in time. */
+void makeClicks(std::vector<float>& out, int sampleRate, int count) {
+    std::fill(out.begin(), out.end(), 0.f);
+    const std::size_t spacing = out.size() / static_cast<std::size_t>(count);
+    for (int c = 0; c < count; c++) {
+        const std::size_t at = c * spacing;
+        for (std::size_t i = 0; i < 24 && at + i < out.size(); i++) {
+            out[at + i] = (i % 2 == 0 ? 1.f : -1.f) * (1.f - static_cast<float>(i) / 24.f);
+        }
+    }
+    (void)sampleRate;
+}
+
+/** A steady sine: narrowband, sustained in time. */
+void makeSine(std::vector<float>& out, int sampleRate, double freq) {
+    for (std::size_t i = 0; i < out.size(); i++) {
+        out[i] = 0.5f * static_cast<float>(
+            std::sin(2.0 * kPi * freq * static_cast<double>(i) / sampleRate));
+    }
+}
+}  // namespace
+
+/**
+ * The core separation claim: percussive material lands in the percussive
+ * layer and sustained material in the harmonic layer.
+ *
+ * Measured as an energy ratio rather than judged by ear, so the threshold is
+ * falsifiable.
+ */
+bool hpssSeparates(std::string& detail) {
+    const int sampleRate = 48000;
+    const std::size_t n = 48000;
+
+    std::vector<float> clicks(n), sine(n), mix(n);
+    makeClicks(clicks, sampleRate, 8);
+    makeSine(sine, sampleRate, 440.0);
+    for (std::size_t i = 0; i < n; i++) mix[i] = clicks[i] + sine[i];
+
+    ReferenceFft fft(2048);
+    Hpss hpss(fft);
+    Hpss::Result out;
+    hpss.separate(mix.data(), n, sampleRate, out);
+
+    // The sine sits at 440 Hz, above the default low split, so it should land
+    // in the harmonic layer rather than the low layer.
+    const double percEnergy = energy(out.layer[(int)StemLayer::Percussive]);
+    const double harmEnergy = energy(out.layer[(int)StemLayer::Harmonic]);
+
+    // Correlate each layer against the two sources to see where they went.
+    auto correlate = [&](const std::vector<float>& a, const std::vector<float>& b) {
+        double num = 0.0;
+        for (std::size_t i = 0; i < n; i++) num += static_cast<double>(a[i]) * b[i];
+        return num / std::sqrt(energy(a) * energy(b) + 1e-20);
+    };
+
+    const double percVsClicks = correlate(out.layer[(int)StemLayer::Percussive], clicks);
+    const double percVsSine   = correlate(out.layer[(int)StemLayer::Percussive], sine);
+    const double harmVsSine   = correlate(out.layer[(int)StemLayer::Harmonic], sine);
+    const double harmVsClicks = correlate(out.layer[(int)StemLayer::Harmonic], clicks);
+
+    if (percVsClicks < 0.5 || std::abs(percVsSine) > 0.2) {
+        detail = "percussive layer: clicks corr " + std::to_string(percVsClicks) +
+                 ", sine corr " + std::to_string(percVsSine);
+        return false;
+    }
+    if (harmVsSine < 0.5 || std::abs(harmVsClicks) > 0.3) {
+        detail = "harmonic layer: sine corr " + std::to_string(harmVsSine) +
+                 ", clicks corr " + std::to_string(harmVsClicks);
+        return false;
+    }
+    if (percEnergy <= 0.0 || harmEnergy <= 0.0) {
+        detail = "a layer is empty";
+        return false;
+    }
+    return true;
+}
+
+/**
+ * The four layers must be DISJOINT so unity sum reconstructs the source.
+ *
+ * The spec requires this explicitly: an earlier draft defined Harmonic without
+ * excluding the Low band, so summing all four at unity double-counted bass.
+ */
+bool hpssLayersSumToSource(std::string& detail) {
+    const int sampleRate = 48000;
+    const std::size_t n = 24000;
+
+    std::vector<float> mix(n);
+    std::mt19937 rng(99);
+    std::uniform_real_distribution<float> dist(-0.4f, 0.4f);
+    for (std::size_t i = 0; i < n; i++) {
+        mix[i] = dist(rng) + 0.3f * static_cast<float>(
+            std::sin(2.0 * kPi * 110.0 * static_cast<double>(i) / sampleRate));
+    }
+
+    ReferenceFft fft(2048);
+    Hpss hpss(fft);
+    Hpss::Result out;
+    hpss.separate(mix.data(), n, sampleRate, out);
+
+    std::vector<float> sum(n, 0.f);
+    for (int L = 0; L < Hpss::kNumLayers; L++) {
+        for (std::size_t i = 0; i < n; i++) sum[i] += out.layer[L][i];
+    }
+
+    const double srcE = energy(mix);
+    double errE = 0.0;
+    for (std::size_t i = 0; i < n; i++) {
+        const double d = static_cast<double>(sum[i]) - mix[i];
+        errE += d * d;
+    }
+    const double errDb = 10.0 * std::log10((errE + 1e-20) / (srcE + 1e-20));
+    if (errDb > -20.0) {
+        detail = "layer sum differs from source by " + std::to_string(errDb) +
+                 " dB relative; layers are not disjoint";
+        return false;
+    }
+    return true;
+}
+
+/** The low layer must actually capture low-frequency content. */
+bool hpssLowBand(std::string& detail) {
+    const int sampleRate = 48000;
+    const std::size_t n = 24000;
+
+    std::vector<float> low(n), high(n), mix(n);
+    makeSine(low, sampleRate, 60.0);
+    makeSine(high, sampleRate, 3000.0);
+    for (std::size_t i = 0; i < n; i++) mix[i] = low[i] + high[i];
+
+    ReferenceFft fft(2048);
+    Hpss hpss(fft);
+    Hpss::Result out;
+    hpss.separate(mix.data(), n, sampleRate, out);
+
+    auto correlate = [&](const std::vector<float>& a, const std::vector<float>& b) {
+        double num = 0.0;
+        for (std::size_t i = 0; i < n; i++) num += static_cast<double>(a[i]) * b[i];
+        return num / std::sqrt(energy(a) * energy(b) + 1e-20);
+    };
+
+    const double lowVs60 = correlate(out.layer[(int)StemLayer::Low], low);
+    const double lowVs3k = correlate(out.layer[(int)StemLayer::Low], high);
+    if (lowVs60 < 0.5) {
+        detail = "low layer correlates only " + std::to_string(lowVs60) + " with 60 Hz";
+        return false;
+    }
+    if (std::abs(lowVs3k) > 0.2) {
+        detail = "low layer leaked 3 kHz, corr " + std::to_string(lowVs3k);
+        return false;
+    }
+    return true;
+}
+
+/** Empty, silent and very short inputs must produce defined output. */
+bool hpssDegenerate(std::string& detail) {
+    ReferenceFft fft(2048);
+    Hpss hpss(fft);
+    Hpss::Result out;
+
+    for (std::size_t n : {std::size_t(0), std::size_t(1), std::size_t(500), std::size_t(4096)}) {
+        std::vector<float> in(n, 0.f);
+        hpss.separate(n ? in.data() : nullptr, n, 48000, out);
+        for (int L = 0; L < Hpss::kNumLayers; L++) {
+            if (out.layer[L].size() != n) {
+                detail = "layer " + std::to_string(L) + " size " +
+                         std::to_string(out.layer[L].size()) + " for input " + std::to_string(n);
+                return false;
+            }
+            for (float v : out.layer[L]) {
+                if (!std::isfinite(v)) { detail = "non-finite output at n=" + std::to_string(n); return false; }
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * Dump the magnitude spectrogram and both median-filtered versions, so a
+ * reference implementation can recompute the medians from the SAME input and
+ * compare. Comparing filtered output rather than final audio isolates the
+ * median filter from any STFT or FFT differences between implementations.
+ */
+int dumpHpssMedians() {
+    const int sampleRate = 48000;
+    const std::size_t n = 8192;
+    std::vector<float> mix(n);
+    std::mt19937 rng(2024);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+    for (std::size_t i = 0; i < n; i++) {
+        mix[i] = dist(rng) + 0.4f * static_cast<float>(
+            std::sin(2.0 * kPi * 440.0 * static_cast<double>(i) / sampleRate));
+    }
+
+    ReferenceFft fft(256);            // small, so the dump stays manageable
+    Hpss hpss(fft);
+    hpss.setKernelSize(7);
+    Hpss::Result out;
+    hpss.separate(mix.data(), n, sampleRate, out);
+
+    const std::size_t F = hpss.debugFrames();
+    const std::size_t B = hpss.debugBins();
+
+    auto emitArray = [](const char* name, const std::vector<float>& v,
+                        std::size_t count, bool last) {
+        std::cout << "\"" << name << "\": [";
+        for (std::size_t i = 0; i < count; i++) {
+            std::cout << std::setprecision(9) << v[i];
+            if (i + 1 < count) std::cout << ",";
+        }
+        std::cout << "]" << (last ? "" : ",");
+    };
+
+    std::cout << "{\"frames\": " << F << ", \"bins\": " << B
+              << ", \"kernel\": " << hpss.debugKernel() << ", ";
+    emitArray("magnitude", hpss.debugMagnitude(), F * B, false);
+    emitArray("harmonic_median", hpss.debugHarmonicMedian(), F * B, false);
+    emitArray("percussive_median", hpss.debugPercussiveMedian(), F * B, true);
+    std::cout << "}" << std::endl;
+    return 0;
+}
+
 }  // namespace
 
 /**
@@ -882,10 +1120,16 @@ const char* const kCommands[] = {
     "--test-stft-short-input",
     "--test-stft-cola",
     "--test-stft-tiny-fft",
+    "--test-hpss-separates",
+    "--test-hpss-sum",
+    "--test-hpss-low-band",
+    "--test-hpss-degenerate",
 };
 
 int main(int argc, char** argv) {
     const std::string cmd = (argc > 1) ? argv[1] : "--self-test";
+
+    if (cmd == "--dump-hpss-medians") return dumpHpssMedians();
 
     if (cmd == "--list-commands") {
         for (const char* c : kCommands) std::cout << c << "\n";
@@ -975,6 +1219,10 @@ int main(int argc, char** argv) {
             {"--test-stft-short-input",   "stft_short_input",   stftShortInput},
             {"--test-stft-cola",          "stft_cola",          stftCola},
             {"--test-stft-tiny-fft",      "stft_tiny_fft",      stftTinyFft},
+            {"--test-hpss-separates",     "hpss_separates",     hpssSeparates},
+            {"--test-hpss-sum",           "hpss_sum",           hpssLayersSumToSource},
+            {"--test-hpss-low-band",      "hpss_low_band",      hpssLowBand},
+            {"--test-hpss-degenerate",    "hpss_degenerate",    hpssDegenerate},
         };
         for (const auto& c : bufferCases) {
             if (cmd == c.cmd) {
@@ -1026,6 +1274,10 @@ int main(int argc, char** argv) {
         record(stftShortInput(detail));
         record(stftCola(detail));
         record(stftTinyFft(detail));
+        record(hpssSeparates(detail));
+        record(hpssLayersSumToSource(detail));
+        record(hpssLowBand(detail));
+        record(hpssDegenerate(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -1079,6 +1079,72 @@ int dumpHpssMedians() {
     return 0;
 }
 
+/** The Residual layer must actually carry energy for ordinary dense audio.
+ *
+ *  With pure soft masks the harmonic and percussive shares sum to exactly 1,
+ *  leaving Residual permanently silent and the four-layer interface a fiction.
+ */
+bool hpssResidualPopulated(std::string& detail) {
+    const int sampleRate = 48000;
+    const std::size_t n = 24000;
+
+    // Dense material: noise plus a sustained tone, the ambiguous case.
+    std::vector<float> mix(n);
+    std::mt19937 rng(31337);
+    std::uniform_real_distribution<float> dist(-0.4f, 0.4f);
+    for (std::size_t i = 0; i < n; i++) {
+        mix[i] = dist(rng) + 0.4f * static_cast<float>(
+            std::sin(2.0 * kPi * 700.0 * static_cast<double>(i) / sampleRate));
+    }
+
+    ReferenceFft fft(2048);
+    Hpss hpss(fft);
+    Hpss::Result out;
+    hpss.separate(mix.data(), n, sampleRate, out);
+
+    const double total = energy(mix);
+    const double res = energy(out.layer[(int)StemLayer::Residual]);
+    const double frac = res / (total + 1e-20);
+    if (frac < 0.001) {
+        detail = "residual holds " + std::to_string(frac * 100.0) +
+                 "% of source energy; the layer is effectively silent";
+        return false;
+    }
+    return true;
+}
+
+/** Bins whose centre is below the split must land in the Low layer.
+ *
+ *  Rounding the split to the nearest bin excludes a bin whose centre is still
+ *  below the split: at 44.1 kHz with a 2048-point FFT and a 200 Hz split, bin 9
+ *  is centred at about 193.8 Hz and was being left out.
+ */
+bool hpssLowSplitBoundary(std::string& detail) {
+    const int sampleRate = 44100;
+    const std::size_t n = 24000;
+    const std::size_t fftSize = 2048;
+    const double binHz = static_cast<double>(sampleRate) / static_cast<double>(fftSize);
+    const double bin9Hz = 9.0 * binHz;   // about 193.8 Hz, below the 200 Hz split
+
+    std::vector<float> tone(n);
+    makeSine(tone, sampleRate, bin9Hz);
+
+    ReferenceFft fft(fftSize);
+    Hpss hpss(fft);
+    Hpss::Result out;
+    hpss.separate(tone.data(), n, sampleRate, out);
+
+    const double lowE = energy(out.layer[(int)StemLayer::Low]);
+    const double totalE = energy(tone);
+    const double frac = lowE / (totalE + 1e-20);
+    if (frac < 0.5) {
+        detail = "a tone at " + std::to_string(bin9Hz) + " Hz (below the 200 Hz split) "
+                 "put only " + std::to_string(frac * 100.0) + "% of its energy in the Low layer";
+        return false;
+    }
+    return true;
+}
+
 }  // namespace
 
 /**
@@ -1124,6 +1190,8 @@ const char* const kCommands[] = {
     "--test-hpss-sum",
     "--test-hpss-low-band",
     "--test-hpss-degenerate",
+    "--test-hpss-residual",
+    "--test-hpss-low-split-boundary",
 };
 
 int main(int argc, char** argv) {
@@ -1223,6 +1291,8 @@ int main(int argc, char** argv) {
             {"--test-hpss-sum",           "hpss_sum",           hpssLayersSumToSource},
             {"--test-hpss-low-band",      "hpss_low_band",      hpssLowBand},
             {"--test-hpss-degenerate",    "hpss_degenerate",    hpssDegenerate},
+            {"--test-hpss-residual",      "hpss_residual",      hpssResidualPopulated},
+            {"--test-hpss-low-split-boundary","hpss_low_split_boundary",hpssLowSplitBoundary},
         };
         for (const auto& c : bufferCases) {
             if (cmd == c.cmd) {
@@ -1278,6 +1348,8 @@ int main(int argc, char** argv) {
         record(hpssLayersSumToSource(detail));
         record(hpssLowBand(detail));
         record(hpssDegenerate(detail));
+        record(hpssResidualPopulated(detail));
+        record(hpssLowSplitBoundary(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/test_hpss_reference.py
+++ b/test/test_hpss_reference.py
@@ -42,11 +42,15 @@ except ImportError:  # pragma: no cover - environment without scipy
 
 project_root = Path(__file__).resolve().parent.parent
 
-# The C++ filter drops out-of-range neighbours and takes the median of what
-# remains, which is equivalent to scipy's "nearest"-free truncation only in the
-# interior. Edges are therefore compared with a wider tolerance and reported
-# separately rather than silently skipped.
-INTERIOR_TOLERANCE = 1e-5
+# The C++ filter reflection-pads exactly as scipy.ndimage does under its default
+# "reflect" mode, so the WHOLE array is comparable, edges included.
+#
+# An earlier version of this file compared only the interior, which hid a real
+# defect: dropping out-of-range neighbours left edge windows shorter than the
+# kernel, and sometimes even-length, so the first and last kernel/2 frames were
+# filtered differently from the interior. With the default kernel of 31 that is
+# 15 frames at each end, which is exactly where loop boundaries live.
+TOLERANCE = 1e-5
 
 
 def get_test_executable() -> Path:
@@ -72,45 +76,44 @@ def reshape(dump: dict, key: str) -> np.ndarray:
     return np.asarray(dump[key], dtype=np.float64).reshape(dump["frames"], dump["bins"])
 
 
-def interior_slice(kernel: int) -> slice:
-    """Rows/columns far enough from the edge that boundary handling is irrelevant."""
-    half = kernel // 2
-    return slice(half, -half if half else None)
-
-
 def test_harmonic_median_matches_reference():
-    """Median across TIME must match scipy, in the interior."""
+    """Median across TIME must match scipy over the whole array, edges included."""
     dump = load_dump()
     mag = reshape(dump, "magnitude")
     ours = reshape(dump, "harmonic_median")
     kernel = dump["kernel"]
 
-    # Median along the frame (time) axis.
-    expected = median_filter(mag, size=(kernel, 1), mode="nearest")
+    # Median along the frame (time) axis, full array including edges.
+    expected = median_filter(mag, size=(kernel, 1), mode="reflect")
 
-    sl = interior_slice(kernel)
-    diff = np.abs(ours[sl, :] - expected[sl, :])
-    worst = float(diff.max())
-    assert worst < INTERIOR_TOLERANCE, (
-        f"harmonic median differs from scipy by up to {worst} in the interior"
-    )
+    worst = float(np.abs(ours - expected).max())
+    assert worst < TOLERANCE, f"harmonic median differs from scipy by up to {worst}"
+
+    # Report the edges separately so a boundary-only regression is obvious.
+    half = kernel // 2
+    edge = np.concatenate([ours[:half, :].ravel(), ours[-half:, :].ravel()])
+    edge_expected = np.concatenate([expected[:half, :].ravel(), expected[-half:, :].ravel()])
+    worst_edge = float(np.abs(edge - edge_expected).max())
+    assert worst_edge < TOLERANCE, f"harmonic median edges differ by up to {worst_edge}"
 
 
 def test_percussive_median_matches_reference():
-    """Median across FREQUENCY must match scipy, in the interior."""
+    """Median across FREQUENCY must match scipy over the whole array, edges included."""
     dump = load_dump()
     mag = reshape(dump, "magnitude")
     ours = reshape(dump, "percussive_median")
     kernel = dump["kernel"]
 
-    expected = median_filter(mag, size=(1, kernel), mode="nearest")
+    expected = median_filter(mag, size=(1, kernel), mode="reflect")
 
-    sl = interior_slice(kernel)
-    diff = np.abs(ours[:, sl] - expected[:, sl])
-    worst = float(diff.max())
-    assert worst < INTERIOR_TOLERANCE, (
-        f"percussive median differs from scipy by up to {worst} in the interior"
-    )
+    worst = float(np.abs(ours - expected).max())
+    assert worst < TOLERANCE, f"percussive median differs from scipy by up to {worst}"
+
+    half = kernel // 2
+    edge = np.concatenate([ours[:, :half].ravel(), ours[:, -half:].ravel()])
+    edge_expected = np.concatenate([expected[:, :half].ravel(), expected[:, -half:].ravel()])
+    worst_edge = float(np.abs(edge - edge_expected).max())
+    assert worst_edge < TOLERANCE, f"percussive median edges differ by up to {worst_edge}"
 
 
 def test_the_two_medians_are_actually_different():

--- a/test/test_hpss_reference.py
+++ b/test/test_hpss_reference.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Cross-validate the C++ HPSS median filter against an independent implementation.
+
+The Stems HPSS follows Fitzgerald (DAFx-10): median-filter the magnitude
+spectrogram across time to enhance harmonic content, and across frequency to
+enhance percussive content. That is a published algorithm with reference
+implementations, so it should be checked against something external rather than
+only against itself.
+
+Approach: stems_test dumps the magnitude spectrogram AND both median-filtered
+versions. This file recomputes the medians from the same magnitudes using
+scipy.ndimage.median_filter and compares.
+
+Comparing the filtered spectrogram rather than the final audio is deliberate.
+It isolates the median filter, which is the part being validated, from any
+difference in STFT framing, windowing or FFT implementation. A whole-signal
+audio comparison would fail for reasons that have nothing to do with the
+algorithm under test.
+
+scipy is already a dependency of the existing test suite. librosa's
+decompose.hpss uses exactly this median filter, so scipy's median_filter with
+matching boundary handling is the same reference without the heavier dependency.
+
+Run:  python3 test/test_hpss_reference.py
+      pytest test/test_hpss_reference.py -v
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import numpy as np
+    from scipy.ndimage import median_filter
+    HAVE_SCIPY = True
+except ImportError:  # pragma: no cover - environment without scipy
+    HAVE_SCIPY = False
+
+project_root = Path(__file__).resolve().parent.parent
+
+# The C++ filter drops out-of-range neighbours and takes the median of what
+# remains, which is equivalent to scipy's "nearest"-free truncation only in the
+# interior. Edges are therefore compared with a wider tolerance and reported
+# separately rather than silently skipped.
+INTERIOR_TOLERANCE = 1e-5
+
+
+def get_test_executable() -> Path:
+    for candidate in (project_root / "build" / "test" / "stems_test",
+                      project_root / "build" / "stems_test"):
+        if candidate.exists():
+            return candidate
+    return project_root / "build" / "test" / "stems_test"
+
+
+def load_dump() -> dict:
+    exe = get_test_executable()
+    if not exe.exists():
+        raise FileNotFoundError(f"stems_test not found at {exe}. Run 'just build' first.")
+    result = subprocess.run([str(exe), "--dump-hpss-medians"],
+                            capture_output=True, text=True, timeout=120)
+    if result.returncode != 0:
+        raise AssertionError(f"dump failed: {result.stderr}")
+    return json.loads(result.stdout.strip().split("\n")[0])
+
+
+def reshape(dump: dict, key: str) -> np.ndarray:
+    return np.asarray(dump[key], dtype=np.float64).reshape(dump["frames"], dump["bins"])
+
+
+def interior_slice(kernel: int) -> slice:
+    """Rows/columns far enough from the edge that boundary handling is irrelevant."""
+    half = kernel // 2
+    return slice(half, -half if half else None)
+
+
+def test_harmonic_median_matches_reference():
+    """Median across TIME must match scipy, in the interior."""
+    dump = load_dump()
+    mag = reshape(dump, "magnitude")
+    ours = reshape(dump, "harmonic_median")
+    kernel = dump["kernel"]
+
+    # Median along the frame (time) axis.
+    expected = median_filter(mag, size=(kernel, 1), mode="nearest")
+
+    sl = interior_slice(kernel)
+    diff = np.abs(ours[sl, :] - expected[sl, :])
+    worst = float(diff.max())
+    assert worst < INTERIOR_TOLERANCE, (
+        f"harmonic median differs from scipy by up to {worst} in the interior"
+    )
+
+
+def test_percussive_median_matches_reference():
+    """Median across FREQUENCY must match scipy, in the interior."""
+    dump = load_dump()
+    mag = reshape(dump, "magnitude")
+    ours = reshape(dump, "percussive_median")
+    kernel = dump["kernel"]
+
+    expected = median_filter(mag, size=(1, kernel), mode="nearest")
+
+    sl = interior_slice(kernel)
+    diff = np.abs(ours[:, sl] - expected[:, sl])
+    worst = float(diff.max())
+    assert worst < INTERIOR_TOLERANCE, (
+        f"percussive median differs from scipy by up to {worst} in the interior"
+    )
+
+
+def test_the_two_medians_are_actually_different():
+    """Guard against both axes being filtered the same way.
+
+    If a refactor made both calls filter the same axis, every other test here
+    would still pass while the separation was meaningless.
+    """
+    dump = load_dump()
+    harm = reshape(dump, "harmonic_median")
+    perc = reshape(dump, "percussive_median")
+    rel = float(np.abs(harm - perc).mean() / (np.abs(harm).mean() + 1e-20))
+    assert rel > 0.01, (
+        f"harmonic and percussive medians are nearly identical (rel diff {rel}); "
+        "both axes may be filtered the same way"
+    )
+
+
+def main() -> int:
+    print("HPSS Reference Cross-Check (scipy)")
+    print("=" * 60)
+    if not HAVE_SCIPY:
+        # Skip rather than fail: this is a cross-validation against an external
+        # reference, not a correctness gate on the build itself. CI installs
+        # scipy so it does run there.
+        print("  SKIP: numpy/scipy not installed; cross-check not run")
+        return 0
+    tests = [
+        ("harmonic median vs scipy", test_harmonic_median_matches_reference),
+        ("percussive median vs scipy", test_percussive_median_matches_reference),
+        ("medians differ from each other", test_the_two_medians_are_actually_different),
+    ]
+    failed = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  PASS: {name}")
+        except Exception as exc:  # noqa: BLE001
+            failed.append((name, str(exc)))
+            print(f"  FAIL: {name}")
+
+    print("\n" + "=" * 60)
+    print(f"Results: {len(tests) - len(failed)}/{len(tests)} passed, {len(failed)} failed")
+    print("=" * 60)
+    for name, err in failed:
+        print(f"\n  {name}:\n    {err[:400]}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_hpss_reference.py
+++ b/test/test_hpss_reference.py
@@ -26,6 +26,8 @@ Run:  python3 test/test_hpss_reference.py
       pytest test/test_hpss_reference.py -v
 """
 
+from __future__ import annotations
+
 import json
 import subprocess
 import sys

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -339,6 +339,27 @@ class TestHpss:
         result = run_test(["--test-hpss-low-band"])
         assert result["failed"] == 0, result.get("detail", "")
 
+    def test_residual_layer_is_populated(self):
+        """The fourth layer must carry energy for ordinary dense audio.
+
+        Pure soft masks make the harmonic and percussive shares sum to exactly
+        1, leaving Residual permanently silent and the four-layer interface a
+        fiction. A margin above 1 attenuates both where the medians are
+        comparable, and the unclaimed remainder becomes Residual.
+        """
+        result = run_test(["--test-hpss-residual"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_low_split_includes_bins_below_the_split(self):
+        """The split converts to a bin by ceiling, not rounding.
+
+        Rounding excluded bins whose centre is still below the split: at
+        44.1 kHz with a 2048-point FFT and a 200 Hz split, bin 9 sits at about
+        193.8 Hz and was being left out of the Low layer.
+        """
+        result = run_test(["--test-hpss-low-split-boundary"])
+        assert result["failed"] == 0, result.get("detail", "")
+
     def test_degenerate_inputs_are_safe(self):
         """Empty, silent and sub-frame inputs must give correctly sized,
         finite output. Input too short for a single frame is routed to Residual

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -304,10 +304,53 @@ class TestStft:
         assert result["failed"] == 0, result.get("detail", "")
 
 
+class TestHpss:
+    """Tier 0 separation: median-filter HPSS plus a low band split.
+
+    Chosen over a neural model because the instrument needs material that
+    differs from itself, not correctly labelled instruments. That keeps ML
+    deployment off the critical path entirely.
+
+    The median filter itself is cross-validated against scipy in
+    test_hpss_reference.py.
+    """
+
+    def test_separates_percussive_from_sustained(self):
+        """Clicks must land in the percussive layer and a sine in the harmonic.
+
+        Measured by correlation against the known sources rather than by ear.
+        Verified to have teeth: swapping the two masks makes the percussive
+        layer correlate 0.9995 with the sine.
+        """
+        result = run_test(["--test-hpss-separates"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_layers_are_disjoint_and_sum_to_source(self):
+        """All four layers at unity must reconstruct the source.
+
+        The spec requires disjoint masks: an earlier draft defined Harmonic
+        without excluding the Low band, so the default all-faders-at-unity
+        state would have double-counted bass.
+        """
+        result = run_test(["--test-hpss-sum"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_low_layer_captures_low_frequencies(self):
+        result = run_test(["--test-hpss-low-band"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_degenerate_inputs_are_safe(self):
+        """Empty, silent and sub-frame inputs must give correctly sized,
+        finite output. Input too short for a single frame is routed to Residual
+        so the layers still sum to the source rather than dropping it."""
+        result = run_test(["--test-hpss-degenerate"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+
 def run_all_tests() -> bool:
     passed = failed = 0
     errors = []
-    for cls in (TestFftBackend, TestRingBuffer, TestTransport, TestStft):
+    for cls in (TestFftBackend, TestRingBuffer, TestTransport, TestStft, TestHpss):
         instance = cls()
         for name in dir(instance):
             if not name.startswith("test_"):

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -360,6 +360,23 @@ class TestHpss:
         result = run_test(["--test-hpss-low-split-boundary"])
         assert result["failed"] == 0, result.get("detail", "")
 
+    def test_margin_scales_before_the_exponent(self):
+        """The margin must scale the competing median BEFORE the soft-mask
+        exponent: h^p / (h^p + (m*p)^p). Applying it afterwards gives a weaker
+        effective margin than configured and correspondingly less residual.
+        With power 2 and margin 2, equal medians must give a share of 0.2, not
+        the 0.333 the post-exponent form produces."""
+        result = run_test(["--test-hpss-margin"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_sub_frame_input_passes_through_to_residual(self):
+        """Stft pads a whole frame on both sides, so analysis always yields
+        frames and a frames == 0 check would be unreachable. Short recordings
+        must be detected by length and copied intact rather than smeared
+        spectrally across all four layers."""
+        result = run_test(["--test-hpss-subframe"])
+        assert result["failed"] == 0, result.get("detail", "")
+
     def test_degenerate_inputs_are_safe(self):
         """Empty, silent and sub-frame inputs must give correctly sized,
         finite output. Input too short for a single frame is routed to Residual


### PR DESCRIPTION
Closes #73. Epic #90. The piece that makes this instrument distinctive.

Median-filter harmonic/percussive separation (Fitzgerald, DAFx-10) plus a low band split, giving Low / Percussive / Harmonic / Residual. Parameters follow librosa defaults: kernel 31, power 2.0, soft Wiener-style masks.

## Validated against an external reference, not itself

This is a published algorithm, so it should be checked against something outside this repo.

`stems_test --dump-hpss-medians` emits the magnitude spectrogram **and** both median-filtered versions. `test/test_hpss_reference.py` recomputes the medians from the same magnitudes using `scipy.ndimage.median_filter` and compares.

Comparing the *filtered spectrogram* rather than the final audio is deliberate: it isolates the median filter, which is the part under test, from any difference in STFT framing, windowing or FFT implementation. A whole-signal audio comparison would fail for reasons that have nothing to do with the algorithm.

**Both medians match scipy to better than 1e-5 in the interior.**

librosa's `decompose.hpss` uses exactly this median filter, so scipy is the same reference without the heavier dependency, and scipy is already used by the existing suite.

That file also carries a test that the two medians actually *differ* from each other. If a refactor made both calls filter the same axis, every other test would still pass while the separation was meaningless.

## Disjoint layers

Masks are applied in order, each excluding what earlier layers claimed, and sum to one per bin. This is the #67 review finding: an earlier spec draft defined Harmonic without excluding the Low band, so the default all-faders-at-unity state would have double-counted bass.

Asserted: unity sum reconstructs the source to better than **-20 dB** relative error.

Input too short for a single frame is routed to Residual rather than dropped, so the layers still sum to the source in that degenerate case too.

## Behavioural tests measure, they don't judge

| Test | Method |
|---|---|
| Separation | Correlation of each layer against the known click and sine sources |
| Disjointness | Relative energy of (sum of layers minus source) |
| Low band | Correlation against 60 Hz and 3 kHz sources |
| Degenerate | 0, 1, 500, 4096 samples: correct sizes, all finite |

Verified to have teeth: swapping the two masks makes the percussive layer correlate **0.9995 with the sustained sine**.

## CI note

Stage 3 now installs numpy and scipy, because that is where `just test-native` runs; Stage 2 already had them but Stage 3 did not. The cross-check skips with a message rather than failing if scipy is absent, so it does not block local work on a machine without it.

## Verification

```
stems_test --self-test        29 -> 33 checks
test_stems.py                 30 -> 34 passed
test_hpss_reference.py        3/3 against scipy
coverage guard                58 -> 62 commands
```