### PR TITLE
S7: separation worker with generation IDs and epoch reclamation

### DIFF
--- a/src/common/stems/SeparationWorker.hpp
+++ b/src/common/stems/SeparationWorker.hpp
@@ -1,0 +1,292 @@
+#pragma once
+/******************************************************************************
+ * SeparationWorker - background separation and safe publication for Stems
+ *
+ * The first thread in this repository, so the ownership rules are spelled out
+ * rather than assumed.
+ *
+ * Three requirements from specs/Stems.md, all of which came out of review:
+ *
+ *  1. Immutable per-job input snapshots with generation IDs. The worker never
+ *     reads the live ring buffer, because process() may be mutating it if the
+ *     user starts a new take mid-job. A result whose generation is no longer
+ *     current is discarded rather than published, so a superseded take can
+ *     never overwrite a newer one.
+ *
+ *  2. Publication by a single atomic pointer swap. The audio thread pins the
+ *     pointer once per process() call, so it sees either the old set or the new
+ *     one and never a partial one.
+ *
+ *  3. A retirement queue, not shared ownership. An atomic swap alone says
+ *     nothing about when the audio thread has finished with the previous set.
+ *     Freeing on the worker immediately risks use-after-free; shared_ptr risks
+ *     the final release landing on the audio thread and deallocating tens of
+ *     megabytes there; keeping every old set leaks. Retired pointers go back to
+ *     the worker and are destroyed there.
+ *
+ * Reclamation uses an epoch counter rather than reference counting, so the
+ * audio side pays only two relaxed atomic stores per block and never touches an
+ * allocator. A retired set is destroyed once the reader has been observed to
+ * enter a later critical section than the one that could still hold it.
+ *
+ * Audio-thread contract: acquire() and release() allocate nothing, take no
+ * locks, and never free. Everything else runs on the worker or the UI thread.
+ ******************************************************************************/
+
+#include "FftBackend.hpp"
+#include "Hpss.hpp"
+#include "ReferenceFft.hpp"
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace WiggleRoom {
+namespace stems {
+
+/** An immutable, fully-formed separation result. */
+struct StemSet {
+    static constexpr int kNumLayers = Hpss::kNumLayers;
+    std::vector<float> layer[kNumLayers];
+    uint64_t generation = 0;
+};
+
+class SeparationWorker {
+public:
+    SeparationWorker() = default;
+
+    ~SeparationWorker() { stop(); }
+
+    SeparationWorker(const SeparationWorker&) = delete;
+    SeparationWorker& operator=(const SeparationWorker&) = delete;
+
+    void start() {
+        if (running_.exchange(true)) return;
+        thread_ = std::thread([this] { run(); });
+    }
+
+    /** Join the worker and free everything. Not audio-thread safe. */
+    void stop() {
+        if (!running_.exchange(false)) {
+            reclaimAll();
+            return;
+        }
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            wake_.notify_all();
+        }
+        if (thread_.joinable()) thread_.join();
+        reclaimAll();
+    }
+
+    /**
+     * Queue a separation job from an immutable copy of @p input.
+     *
+     * The copy is taken here, on the calling thread, precisely so the worker
+     * never reads a buffer that process() may be writing.
+     *
+     * @return the generation ID assigned to this job. Generations start at 1,
+     *         so 0 is always "nothing submitted".
+     */
+    uint64_t submit(const float* input, std::size_t length, int sampleRate) {
+        const uint64_t gen = nextGeneration_.fetch_add(1, std::memory_order_relaxed) + 1;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            pending_.assign(input, input + length);
+            pendingRate_ = sampleRate;
+            pendingGeneration_ = gen;
+            hasPending_ = true;
+        }
+        wake_.notify_one();
+        return gen;
+    }
+
+    /** Generation of the most recently submitted job. */
+    uint64_t currentGeneration() const {
+        return nextGeneration_.load(std::memory_order_relaxed);
+    }
+
+    /**
+     * Pin the published set for the duration of a process() call.
+     * Returns nullptr when nothing has been published yet.
+     *
+     * Must be paired with release(). Allocation-free and lock-free.
+     */
+    const StemSet* acquire() {
+        // Enter a critical section: publish an odd epoch so the worker knows a
+        // reader may be holding whatever is currently live.
+        readerEpoch_.fetch_add(1, std::memory_order_acq_rel);
+        return published_.load(std::memory_order_acquire);
+    }
+
+    void release(const StemSet* /*set*/) {
+        // Leave the critical section: back to an even epoch. The worker can now
+        // reclaim anything retired before this section began.
+        readerEpoch_.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    /** Sets currently allocated, live plus awaiting reclamation. Diagnostics. */
+    std::size_t liveSetCount() const {
+        std::lock_guard<std::mutex> lock(retiredMutex_);
+        return retired_.size() + (published_.load(std::memory_order_relaxed) ? 1 : 0);
+    }
+
+    /**
+     * Sets freed on a thread other than the worker. Must always be zero: a
+     * non-zero value means a multi-megabyte deallocation happened on the audio
+     * thread, which is the failure this design exists to prevent.
+     */
+    std::size_t debugFreedOnAcquireThread() const {
+        return freedOffWorker_.load(std::memory_order_relaxed);
+    }
+
+    /** Jobs the worker actually began separating. */
+    uint64_t debugJobsStarted() const { return jobsStarted_.load(std::memory_order_relaxed); }
+
+    /** Jobs discarded after separation because they had been superseded. */
+    uint64_t debugJobsDiscarded() const { return jobsDiscarded_.load(std::memory_order_relaxed); }
+
+private:
+    void run() {
+        workerId_.store(std::this_thread::get_id(), std::memory_order_release);
+        ReferenceFft fft(2048);
+        Hpss hpss(fft);
+
+        while (running_.load(std::memory_order_acquire)) {
+            std::vector<float> input;
+            int sampleRate = 48000;
+            uint64_t generation = 0;
+
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                wake_.wait(lock, [this] {
+                    return hasPending_ || !running_.load(std::memory_order_acquire);
+                });
+                if (!running_.load(std::memory_order_acquire)) break;
+                input = std::move(pending_);
+                pending_.clear();
+                sampleRate = pendingRate_;
+                generation = pendingGeneration_;
+                hasPending_ = false;
+            }
+
+            // Drop the job if it was superseded while we were waiting.
+            if (generation != currentGeneration()) {
+                jobsDiscarded_.fetch_add(1, std::memory_order_relaxed);
+                tryReclaim();
+                continue;
+            }
+            jobsStarted_.fetch_add(1, std::memory_order_relaxed);
+
+            auto set = std::unique_ptr<StemSet>(new StemSet());
+            set->generation = generation;
+
+            Hpss::Result result;
+            hpss.separate(input.data(), input.size(), sampleRate, result);
+            for (int L = 0; L < StemSet::kNumLayers; L++) {
+                set->layer[L] = std::move(result.layer[L]);
+            }
+
+            // Check again: separation is slow, and the take may have been
+            // superseded while it ran. Publishing now would overwrite a newer
+            // result with an older one.
+            if (generation != currentGeneration()) {
+                jobsDiscarded_.fetch_add(1, std::memory_order_relaxed);
+                tryReclaim();
+                continue;
+            }
+
+            publish(set.release());
+            tryReclaim();
+        }
+    }
+
+    void publish(StemSet* fresh) {
+        StemSet* old = published_.exchange(fresh, std::memory_order_acq_rel);
+        if (!old) return;
+        // Record the epoch at retirement. The set becomes reclaimable once the
+        // reader is observed outside any critical section that began at or
+        // before this point.
+        std::lock_guard<std::mutex> lock(retiredMutex_);
+        retired_.push_back({old, readerEpoch_.load(std::memory_order_acquire)});
+    }
+
+    /** Free retired sets the reader can no longer be holding. Worker only. */
+    void tryReclaim() {
+        std::lock_guard<std::mutex> lock(retiredMutex_);
+        const uint64_t now = readerEpoch_.load(std::memory_order_acquire);
+        for (auto it = retired_.begin(); it != retired_.end();) {
+            // Even epoch means the reader is not inside a critical section.
+            // A strictly later epoch means it has entered and left at least one
+            // since retirement, so it cannot still hold this pointer.
+            const bool readerIdle = (now % 2 == 0);
+            if (readerIdle && now >= it->epoch) {
+                destroySet(it->set, /*shuttingDown=*/false);
+                it = retired_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    /** Free everything unconditionally. Only safe once readers have stopped. */
+    void reclaimAll() {
+        StemSet* live = published_.exchange(nullptr, std::memory_order_acq_rel);
+        // Shutdown frees run on the caller's thread by design, after the worker
+        // has been joined and no reader remains, so they are not counted.
+        destroySet(live, /*shuttingDown=*/true);
+        std::lock_guard<std::mutex> lock(retiredMutex_);
+        for (auto& entry : retired_) destroySet(entry.set, /*shuttingDown=*/true);
+        retired_.clear();
+    }
+
+    /**
+     * Single funnel for every deallocation, so "was this freed off the worker"
+     * is actually measurable rather than assumed. Without this the diagnostic
+     * counter would sit at zero forever and the test asserting it would be
+     * vacuous.
+     */
+    void destroySet(StemSet* set, bool shuttingDown) {
+        if (!set) return;
+        if (!shuttingDown &&
+            std::this_thread::get_id() != workerId_.load(std::memory_order_acquire)) {
+            freedOffWorker_.fetch_add(1, std::memory_order_relaxed);
+        }
+        delete set;
+    }
+
+    struct Retired {
+        StemSet* set;
+        uint64_t epoch;
+    };
+
+    std::atomic<bool> running_{false};
+    std::thread thread_;
+
+    mutable std::mutex mutex_;
+    std::condition_variable wake_;
+    std::vector<float> pending_;
+    int pendingRate_ = 48000;
+    uint64_t pendingGeneration_ = 0;
+    bool hasPending_ = false;
+
+    std::atomic<uint64_t> nextGeneration_{0};
+    std::atomic<StemSet*> published_{nullptr};
+    std::atomic<uint64_t> readerEpoch_{0};
+
+    mutable std::mutex retiredMutex_;
+    std::vector<Retired> retired_;
+    std::atomic<std::size_t> freedOffWorker_{0};
+    std::atomic<std::thread::id> workerId_{};
+    std::atomic<uint64_t> jobsStarted_{0};
+    std::atomic<uint64_t> jobsDiscarded_{0};
+};
+
+}  // namespace stems
+}  // namespace WiggleRoom

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -210,3 +210,8 @@ set_target_properties(stems_test PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
+
+# SeparationWorker is the first threaded code in the repo, so stems_test needs
+# a threading library. Still no Rack SDK linkage.
+find_package(Threads REQUIRED)
+target_link_libraries(stems_test PRIVATE Threads::Threads)

--- a/test/stems_test.cpp
+++ b/test/stems_test.cpp
@@ -34,6 +34,7 @@
 #include "common/stems/ReferenceFft.hpp"
 #include "common/stems/RingBuffer.hpp"
 #include "common/stems/Hpss.hpp"
+#include "common/stems/SeparationWorker.hpp"
 #include "common/stems/Stft.hpp"
 #include "common/stems/Transport.hpp"
 
@@ -42,7 +43,10 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <atomic>
+#include <chrono>
 #include <random>
+#include <thread>
 #include <string>
 #include <vector>
 
@@ -1211,6 +1215,227 @@ bool hpssSubFrameInput(std::string& detail) {
     return true;
 }
 
+// ---------------------------------------------------------------------------
+// SeparationWorker
+// ---------------------------------------------------------------------------
+
+using WiggleRoom::stems::SeparationWorker;
+using WiggleRoom::stems::StemSet;
+
+namespace {
+/** Deterministic test signal. */
+std::vector<float> makeJobInput(std::size_t n, unsigned seed) {
+    std::vector<float> v(n);
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(-0.4f, 0.4f);
+    for (auto& x : v) x = dist(rng);
+    return v;
+}
+
+/** Spin until pred() or the deadline passes. Returns whether pred() held. */
+template <typename Pred>
+bool waitFor(Pred pred, int milliseconds = 15000) {
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(milliseconds);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (pred()) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return pred();
+}
+}  // namespace
+
+/** A submitted job must eventually publish a stem set the audio side can see. */
+bool workerPublishes(std::string& detail) {
+    SeparationWorker worker;
+    worker.start();
+
+    auto input = makeJobInput(16384, 1);
+    const uint64_t gen = worker.submit(input.data(), input.size(), 48000);
+    if (gen == 0) { detail = "submit returned generation 0"; worker.stop(); return false; }
+
+    const bool got = waitFor([&] {
+        const StemSet* s = worker.acquire();
+        const bool ok = (s != nullptr && s->generation == gen);
+        worker.release(s);
+        return ok;
+    });
+    if (!got) { detail = "no stem set published within the timeout"; worker.stop(); return false; }
+
+    const StemSet* s = worker.acquire();
+    bool sized = s && s->layer[0].size() == input.size();
+    worker.release(s);
+    worker.stop();
+    if (!sized) { detail = "published layers are the wrong size"; return false; }
+    return true;
+}
+
+/** A superseded job must never publish over a newer take. */
+bool workerDiscardsStale(std::string& detail) {
+    SeparationWorker worker;
+    worker.start();
+
+    // Big enough that separation takes real time, so the second job genuinely
+    // arrives mid-flight. Submitting back to back does NOT exercise this path:
+    // the pending slot is overwritten and the worker never starts the first job
+    // at all, so the post-separation generation check is never reached.
+    auto first  = makeJobInput(262144, 2);
+    auto second = makeJobInput(8192, 3);
+
+    const uint64_t genA = worker.submit(first.data(), first.size(), 48000);
+
+    // Wait until the worker has actually BEGUN genA before superseding it.
+    if (!waitFor([&] { return worker.debugJobsStarted() >= 1; }, 5000)) {
+        detail = "worker never started the first job";
+        worker.stop();
+        return false;
+    }
+
+    const uint64_t genB = worker.submit(second.data(), second.size(), 48000);
+    if (genB <= genA) { detail = "generations did not advance"; worker.stop(); return false; }
+
+    const bool got = waitFor([&] {
+        const StemSet* s = worker.acquire();
+        const bool ok = (s != nullptr && s->generation == genB);
+        worker.release(s);
+        return ok;
+    });
+    if (!got) { detail = "newer job never published"; worker.stop(); return false; }
+
+    // The in-flight genA must have been discarded rather than published.
+    if (worker.debugJobsDiscarded() == 0) {
+        detail = "no job was discarded; the superseded take was not detected";
+        worker.stop();
+        return false;
+    }
+
+    // Give any straggler a chance to overwrite, then confirm it did not.
+    std::this_thread::sleep_for(std::chrono::milliseconds(400));
+    const StemSet* s = worker.acquire();
+    const bool stillNew = (s != nullptr && s->generation == genB &&
+                           s->layer[0].size() == second.size());
+    worker.release(s);
+    worker.stop();
+    if (!stillNew) { detail = "a stale job published over the newer take"; return false; }
+    return true;
+}
+
+/** Retired sets must be destroyed by the worker, never by the audio side. */
+bool workerRetiresOffAudioThread(std::string& detail) {
+    SeparationWorker worker;
+    worker.start();
+
+    auto input = makeJobInput(8192, 4);
+    for (int i = 0; i < 6; i++) {
+        const uint64_t gen = worker.submit(input.data(), input.size(), 48000);
+        if (!waitFor([&] {
+                const StemSet* s = worker.acquire();
+                const bool ok = (s != nullptr && s->generation == gen);
+                worker.release(s);
+                return ok;
+            })) {
+            detail = "job " + std::to_string(i) + " never published";
+            worker.stop();
+            return false;
+        }
+    }
+
+    // Every set but the live one must have been reclaimed on the worker.
+    const bool reclaimed = waitFor([&] { return worker.liveSetCount() <= 1; });
+    const std::size_t freedOnAudio = worker.debugFreedOnAcquireThread();
+    worker.stop();
+
+    if (!reclaimed) { detail = "retired sets were not reclaimed"; return false; }
+    if (freedOnAudio != 0) {
+        detail = std::to_string(freedOnAudio) + " sets were freed on the acquiring thread";
+        return false;
+    }
+    return true;
+}
+
+/** acquire() must be safe before anything has ever been published. */
+bool workerEmptyAcquire(std::string& detail) {
+    SeparationWorker worker;
+    const StemSet* s = worker.acquire();
+    if (s != nullptr) { detail = "acquire returned non-null before any job"; worker.release(s); return false; }
+    worker.release(s);
+
+    worker.start();
+    const StemSet* s2 = worker.acquire();
+    const bool ok = (s2 == nullptr);
+    worker.release(s2);
+    worker.stop();
+    if (!ok) { detail = "acquire returned non-null before any job was submitted"; return false; }
+    return true;
+}
+
+/** Hammer submit and acquire concurrently, looking for races and leaks. */
+bool workerConcurrentHammer(std::string& detail) {
+    SeparationWorker worker;
+    worker.start();
+
+    auto input = makeJobInput(4096, 5);
+    std::atomic<bool> stop{false};
+    std::atomic<uint64_t> reads{0};
+
+    // Stand in for the audio thread: acquire, read, release, forever.
+    std::thread reader([&] {
+        while (!stop.load(std::memory_order_relaxed)) {
+            const StemSet* s = worker.acquire();
+            if (s) {
+                volatile float sink = 0.f;
+                for (int L = 0; L < 4; L++) {
+                    if (!s->layer[L].empty()) sink += s->layer[L][0];
+                }
+                (void)sink;
+                reads.fetch_add(1, std::memory_order_relaxed);
+            }
+            worker.release(s);
+        }
+    });
+
+    for (int i = 0; i < 40; i++) {
+        worker.submit(input.data(), input.size(), 48000);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(400));
+    stop.store(true);
+    reader.join();
+
+    const std::size_t freedOnAudio = worker.debugFreedOnAcquireThread();
+    worker.stop();
+
+    if (reads.load() == 0) { detail = "reader never saw a published set"; return false; }
+    if (freedOnAudio != 0) {
+        detail = std::to_string(freedOnAudio) + " sets freed on the reader thread";
+        return false;
+    }
+    return true;
+}
+
+/** stop() must terminate promptly and free everything. */
+bool workerCleanShutdown(std::string& detail) {
+    SeparationWorker worker;
+    worker.start();
+    auto input = makeJobInput(32768, 6);
+    worker.submit(input.data(), input.size(), 48000);
+
+    const auto begin = std::chrono::steady_clock::now();
+    worker.stop();
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - begin).count();
+
+    if (elapsed > 5000) {
+        detail = "stop() took " + std::to_string(elapsed) + " ms";
+        return false;
+    }
+    if (worker.liveSetCount() != 0) {
+        detail = std::to_string(worker.liveSetCount()) + " sets still live after stop()";
+        return false;
+    }
+    return true;
+}
+
 }  // namespace
 
 /**
@@ -1260,6 +1485,12 @@ const char* const kCommands[] = {
     "--test-hpss-low-split-boundary",
     "--test-hpss-margin",
     "--test-hpss-subframe",
+    "--test-worker-publishes",
+    "--test-worker-stale",
+    "--test-worker-retire",
+    "--test-worker-empty",
+    "--test-worker-hammer",
+    "--test-worker-shutdown",
 };
 
 int main(int argc, char** argv) {
@@ -1363,6 +1594,12 @@ int main(int argc, char** argv) {
             {"--test-hpss-low-split-boundary","hpss_low_split_boundary",hpssLowSplitBoundary},
             {"--test-hpss-margin",        "hpss_margin",        hpssMarginBeforeExponent},
             {"--test-hpss-subframe",      "hpss_subframe",      hpssSubFrameInput},
+            {"--test-worker-publishes",   "worker_publishes",   workerPublishes},
+            {"--test-worker-stale",       "worker_stale",       workerDiscardsStale},
+            {"--test-worker-retire",      "worker_retire",      workerRetiresOffAudioThread},
+            {"--test-worker-empty",       "worker_empty",       workerEmptyAcquire},
+            {"--test-worker-hammer",      "worker_hammer",      workerConcurrentHammer},
+            {"--test-worker-shutdown",    "worker_shutdown",    workerCleanShutdown},
         };
         for (const auto& c : bufferCases) {
             if (cmd == c.cmd) {
@@ -1422,6 +1659,12 @@ int main(int argc, char** argv) {
         record(hpssLowSplitBoundary(detail));
         record(hpssMarginBeforeExponent(detail));
         record(hpssSubFrameInput(detail));
+        record(workerPublishes(detail));
+        record(workerDiscardsStale(detail));
+        record(workerRetiresOffAudioThread(detail));
+        record(workerEmptyAcquire(detail));
+        record(workerConcurrentHammer(detail));
+        record(workerCleanShutdown(detail));
 
         std::cout << "{\"test\": \"self_test\""
                   << ", \"passed\": " << passed

--- a/test/test_stems.py
+++ b/test/test_stems.py
@@ -385,10 +385,64 @@ class TestHpss:
         assert result["failed"] == 0, result.get("detail", "")
 
 
+class TestSeparationWorker:
+    """Background separation and safe publication.
+
+    The first threaded code in this repository. Verified clean under
+    ThreadSanitizer, not just observed to pass.
+    """
+
+    def test_publishes_a_result(self):
+        result = run_test(["--test-worker-publishes"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_superseded_job_never_publishes(self):
+        """A take superseded mid-separation must be discarded, not published.
+
+        The test waits until the worker has actually BEGUN the first job before
+        submitting the second. Submitting back to back does not exercise this:
+        the pending slot is overwritten and the first job never starts, so the
+        post-separation generation check is never reached. An earlier version of
+        this test made exactly that mistake and passed with the check removed.
+
+        Verified to have teeth: removing the check now fails with "no job was
+        discarded".
+        """
+        result = run_test(["--test-worker-stale"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_retired_sets_are_freed_on_the_worker(self):
+        """A multi-megabyte deallocation must never land on the audio thread.
+
+        Every free goes through one funnel that records the freeing thread, so
+        the counter this asserts on is genuinely wired up rather than a constant
+        zero.
+        """
+        result = run_test(["--test-worker-retire"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_acquire_before_any_job_is_safe(self):
+        """This is the state on patch load."""
+        result = run_test(["--test-worker-empty"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_concurrent_submit_and_acquire(self):
+        """A reader standing in for the audio thread hammers acquire/release
+        while jobs are submitted, checking for races and for frees landing on
+        the wrong thread."""
+        result = run_test(["--test-worker-hammer"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+    def test_shutdown_is_prompt_and_complete(self):
+        result = run_test(["--test-worker-shutdown"])
+        assert result["failed"] == 0, result.get("detail", "")
+
+
 def run_all_tests() -> bool:
     passed = failed = 0
     errors = []
-    for cls in (TestFftBackend, TestRingBuffer, TestTransport, TestStft, TestHpss):
+    for cls in (TestFftBackend, TestRingBuffer, TestTransport, TestStft, TestHpss,
+                TestSeparationWorker):
         instance = cls()
         for name in dir(instance):
             if not name.startswith("test_"):


### PR DESCRIPTION
Closes #74. Epic #90. The threading spine, and the first thread in this repository.

## The three ownership rules

All three came out of the #67 spec review.

**Immutable per-job snapshots with generation IDs.** `submit()` copies the input on the calling thread, so the worker never reads a buffer `process()` may be writing. Generation is checked **twice**, before starting and again after separation completes, because separation is slow and the take can be superseded while it runs.

**Publication by one atomic pointer swap.** The audio side sees the old set or the new one, never a partial one.

**Epoch reclamation, not reference counting.** `acquire()` and `release()` bump a counter marking entry and exit from a critical section. A retired set is destroyed only once the reader is observed outside any section that could still hold it.

`shared_ptr` was rejected because the final release can land on the audio thread and deallocate tens of megabytes there. With epochs the audio side pays two atomic increments per block and never touches an allocator.

## Two weaknesses in my own tests, found before submitting

Worth stating plainly, because both would have shipped a green suite that proved nothing.

**The stale-job test did not exercise its own path.** It submitted two jobs back to back, but `submit()` overwrites the single pending slot, so the worker never *started* the first job and the post-separation check was never reached. Removing that check left the test passing.

It now waits until the worker has actually begun the first job before superseding it, and asserts a job was discarded. Verified:

```
post-separation check REMOVED:  FAIL, "no job was discarded"
check restored:                 PASS
```

**The off-thread-free counter was never incremented**, so asserting it was zero proved nothing. Every deallocation now goes through one funnel recording the freeing thread, with shutdown frees excluded since those run on the caller after the worker is joined.

## Verification

ThreadSanitizer, all six tests:

```
--test-worker-publishes   exit=0 tsan=0
--test-worker-stale       exit=0 tsan=0
--test-worker-retire      exit=0 tsan=0
--test-worker-empty       exit=0 tsan=0
--test-worker-hammer      exit=0 tsan=0
--test-worker-shutdown    exit=0 tsan=0
```

Plus eight repeat runs each of the two timing-sensitive tests, zero failures, since a threading test passing once means very little.

`stems_test` now links `Threads::Threads`. Still no Rack SDK linkage.

```
stems_test --self-test    37 -> 43 checks
test_stems.py             38 -> 44 passed
coverage guard            66 -> 72 commands
```